### PR TITLE
B #-: OneKE: Increase default disk size to 25G (fix)

### DIFF
--- a/packer/service_OneKE/OneKE.pkr.hcl
+++ b/packer/service_OneKE/OneKE.pkr.hcl
@@ -29,7 +29,7 @@ source "qemu" "OneKE" {
   net_device       = "virtio-net"
   format           = "qcow2"
   disk_compression = false
-  disk_size        = 20480
+  disk_size        = 25600
 
   output_directory = var.output_dir
 


### PR DESCRIPTION
In an airgapped scenario, where all features are enabled, 20G may be not enough.