### PR TITLE
M #-: Refactor IP/VIP/EP interpolation

### DIFF
--- a/appliances/VRouter/DNS/tests.rb
+++ b/appliances/VRouter/DNS/tests.rb
@@ -41,9 +41,6 @@ RSpec.describe self do
         ENV['ETH1_IP'] = '20.30.40.50'
         ENV['ETH1_MASK'] = '255.255.0.0'
 
-        ENV['ETH1_ALIAS0_IP'] = '20.30.40.55'
-        ENV['ETH1_ALIAS0_MASK'] = '255.255.0.0'
-
         ENV['ETH2_IP'] = '30.40.50.60'
         ENV['ETH2_MASK'] = '255.0.0.0'
 
@@ -63,25 +60,20 @@ RSpec.describe self do
 
             networks: %w[20.30.0.0/16 30.0.0.0/8 40.50.60.0/24],
 
-            ips: { 'ip0.eth0' => '10.20.30.40',
-                   'ip0.eth1' => '20.30.40.50',
-                   'ip0.eth2' => '30.40.50.60',
-                   'ip0.eth3' => '40.50.60.70',
-                   'ip1.eth1' => '20.30.40.55' },
-
-            vips: { 'vip0.eth0'  => '1.2.3.4',
-                    'vip1.eth0'  => '5.6.7.8',
-                    'vip10.eth0' => '9.10.11.12',
-                    'vip0.eth1'  => '20.30.40.55' },
-
-            eps: {
-                'ep0.eth0'  => '1.2.3.4',     # vip
-                'ep0.eth1'  => '20.30.40.55', # vip
-                'ep0.eth2'  => '30.40.50.60', # ip
-                'ep0.eth3'  => '40.50.60.70', # ip
-                'ep1.eth0'  => '5.6.7.8',     # vip
-                'ep1.eth1'  => '20.30.40.55', # ip
-                'ep10.eth0' => '9.10.11.12' } # vip
+            hosts: { 'ip0.eth0'   => '10.20.30.40',
+                     'ip0.eth1'   => '20.30.40.50',
+                     'ip0.eth2'   => '30.40.50.60',
+                     'ip0.eth3'   => '40.50.60.70',
+                     'vip0.eth1'  => '20.30.40.55',
+                     'vip10.eth0' => '9.10.11.12',
+                     'vip1.eth0'  => '5.6.7.8',
+                     'vip0.eth0'  => '1.2.3.4',
+                     'ep0.eth0'   => '1.2.3.4',
+                     'ep10.eth0'  => '9.10.11.12',
+                     'ep1.eth0'   => '5.6.7.8',
+                     'ep0.eth1'   => '20.30.40.55',
+                     'ep0.eth2'   => '30.40.50.60',
+                     'ep0.eth3'   => '40.50.60.70' }
         })
 
         output = <<~'UNBOUND_CONF'
@@ -133,7 +125,6 @@ RSpec.describe self do
                 local-zone: "vr." static
                 local-data: "ip0.eth0.vr. IN A 10.20.30.40"
                 local-data: "ip0.eth1.vr. IN A 20.30.40.50"
-                local-data: "ip1.eth1.vr. IN A 20.30.40.55"
                 local-data: "ip0.eth2.vr. IN A 30.40.50.60"
                 local-data: "ip0.eth3.vr. IN A 40.50.60.70"
                 local-data: "vip0.eth1.vr. IN A 20.30.40.55"
@@ -141,12 +132,11 @@ RSpec.describe self do
                 local-data: "vip1.eth0.vr. IN A 5.6.7.8"
                 local-data: "vip0.eth0.vr. IN A 1.2.3.4"
                 local-data: "ep0.eth0.vr. IN A 1.2.3.4"
-                local-data: "ep0.eth1.vr. IN A 20.30.40.55"
-                local-data: "ep1.eth1.vr. IN A 20.30.40.55"
-                local-data: "ep0.eth2.vr. IN A 30.40.50.60"
-                local-data: "ep0.eth3.vr. IN A 40.50.60.70"
                 local-data: "ep10.eth0.vr. IN A 9.10.11.12"
                 local-data: "ep1.eth0.vr. IN A 5.6.7.8"
+                local-data: "ep0.eth1.vr. IN A 20.30.40.55"
+                local-data: "ep0.eth2.vr. IN A 30.40.50.60"
+                local-data: "ep0.eth3.vr. IN A 40.50.60.70"
 
             remote-control:
                 control-enable: no
@@ -202,17 +192,14 @@ RSpec.describe self do
 
             networks: %w[20.30.0.0/16 30.0.0.0/8],
 
-            ips: { 'ip0.eth0' => '10.20.30.40',
-                   'ip0.eth1' => '20.30.40.50',
-                   'ip0.eth2' => '30.40.50.60',
-                   'ip0.eth3' => '40.50.60.70' },
-
-            vips: {},
-
-            eps: { 'ep0.eth0' => '10.20.30.40',
-                   'ep0.eth1' => '20.30.40.50',
-                   'ep0.eth2' => '30.40.50.60',
-                   'ep0.eth3' => '40.50.60.70' }
+            hosts: { 'ip0.eth0' => '10.20.30.40',
+                     'ip0.eth1' => '20.30.40.50',
+                     'ip0.eth2' => '30.40.50.60',
+                     'ip0.eth3' => '40.50.60.70',
+                     'ep0.eth0' => '10.20.30.40',
+                     'ep0.eth1' => '20.30.40.50',
+                     'ep0.eth2' => '30.40.50.60',
+                     'ep0.eth3' => '40.50.60.70' }
         })
     end
 
@@ -242,12 +229,10 @@ RSpec.describe self do
 
             networks: %w[1.2.0.0/16],
 
-            ips: { 'ip0.eth0' => '10.20.30.40' },
-
-            vips: { 'vip0.eth1' => '1.2.3.4' },
-
-            eps: { "ep0.eth0" => '10.20.30.40',
-                   'ep0.eth1' => '1.2.3.4' }
+            hosts: { 'ip0.eth0'  => '10.20.30.40',
+                     'vip0.eth1' => '1.2.3.4',
+                     'ep0.eth0'  => '10.20.30.40',
+                     'ep0.eth1'  => '1.2.3.4' }
         })
     end
 end

--- a/appliances/VRouter/Keepalived/tests.rb
+++ b/appliances/VRouter/Keepalived/tests.rb
@@ -63,15 +63,15 @@ RSpec.describe self do
         expect(keepalived_vars[:by_nic]['eth0'][:interval]).to eq '1'
         expect(keepalived_vars[:by_nic]['eth0'][:priority]).to eq '100'
         expect(keepalived_vars[:by_nic]['eth0'][:vrid]).to eq '11'
-        expect(keepalived_vars[:by_nic]['eth0'][:vips][0]).to eq '10.2.11.69'
-        expect(keepalived_vars[:by_nic]['eth0'][:vips][1]).to eq '10.2.11.86'
+        expect(keepalived_vars[:by_nic]['eth0'][:vips][0]).to eq '10.2.11.69/32'
+        expect(keepalived_vars[:by_nic]['eth0'][:vips][1]).to eq '10.2.11.86/32'
         expect(keepalived_vars[:by_nic]['eth0'][:noip]).to be true
 
         expect(keepalived_vars[:by_nic]['eth1'][:interval]).to eq '1'
         expect(keepalived_vars[:by_nic]['eth1'][:priority]).to eq '100'
         expect(keepalived_vars[:by_nic]['eth1'][:vrid]).to eq '11'
-        expect(keepalived_vars[:by_nic]['eth1'][:vips][0]).to eq '10.2.12.69'
-        expect(keepalived_vars[:by_nic]['eth1'][:vips][1]).to eq '10.2.12.86'
+        expect(keepalived_vars[:by_nic]['eth1'][:vips][0]).to eq '10.2.12.69/32'
+        expect(keepalived_vars[:by_nic]['eth1'][:vips][1]).to eq '10.2.12.86/32'
         expect(keepalived_vars[:by_nic]['eth1'][:noip]).to be false
 
         expect(keepalived_vars[:by_vrid]['11'].keys).to eq %w[eth0 eth1]
@@ -112,11 +112,11 @@ RSpec.describe self do
         expect(Service::Keepalived.instance_variable_get(:@interfaces).keys).to eq %w[eth0 eth1]
 
         expect(keepalived_vars[:by_nic]['eth0'][:vrid]).to eq '21'
-        expect(keepalived_vars[:by_nic]['eth0'][:vips][0]).to eq '10.2.21.69'
+        expect(keepalived_vars[:by_nic]['eth0'][:vips][0]).to eq '10.2.21.69/32'
         expect(keepalived_vars[:by_nic]['eth0'][:noip]).to be true
 
         expect(keepalived_vars[:by_nic]['eth1'][:vrid]).to eq '21'
-        expect(keepalived_vars[:by_nic]['eth1'][:vips][0]).to eq '10.2.22.69'
+        expect(keepalived_vars[:by_nic]['eth1'][:vips][0]).to eq '10.2.22.69/32'
         expect(keepalived_vars[:by_nic]['eth1'][:noip]).to be false
 
         expect(keepalived_vars[:by_vrid]['21'].keys).to eq %w[eth0 eth1]
@@ -147,6 +147,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_KEEPALIVED_ETH2_PRIORITY'] = '100'
         ENV['ONEAPP_VNF_KEEPALIVED_ETH2_VRID'] = '31'
 
+        # NOTE: These are ignored because no NIC can handle VRID 31.
         ENV['ONEAPP_VROUTER_ETH2_VIP0'] = '10.2.32.69/24'
         ENV['ONEAPP_VROUTER_ETH2_VIP1'] = '10.2.32.86/24'
 
@@ -182,10 +183,10 @@ RSpec.describe self do
                 priority          100
                 advert_int        1
                 virtual_ipaddress {
-                    10.2.30.69 dev eth0
-                    10.2.30.86 dev eth0
-                    10.2.31.69 dev eth1
-                    10.2.31.86 dev eth1
+                    10.2.30.69/32 dev eth0
+                    10.2.30.86/32 dev eth0
+                    10.2.31.69/32 dev eth1
+                    10.2.31.86/32 dev eth1
                 }
                 virtual_routes {
                     0.0.0.0/0 via 10.2.30.1
@@ -198,7 +199,7 @@ RSpec.describe self do
                 priority          100
                 advert_int        1
                 virtual_ipaddress {
-                    10.2.33.69 dev eth3
+                    10.2.33.69/32 dev eth3
                 }
                 virtual_routes {
                 }

--- a/appliances/VRouter/LVS/execute.rb
+++ b/appliances/VRouter/LVS/execute.rb
@@ -10,17 +10,18 @@ module LVS
     VROUTER_ID = env :VROUTER_ID, nil
 
     def extract_backends(objects = {})
-        @vips ||= detect_vips
-        @n2a  ||= nics_to_addrs
+        @ave ||= [detect_addrs, detect_vips].then do |a, v|
+            [a, v, detect_endpoints(a, v)]
+        end
 
         static = backends.from_env(prefix: 'ONEAPP_VNF_LB')
 
         dynamic = VROUTER_ID.nil? ? backends.from_vms(objects, prefix: 'ONEGATE_LB')
                                   : backends.from_vnets(objects, prefix: 'ONEGATE_LB')
 
-        # Replace all "<ONEAPP_VROUTER_ETHx_VIPy>" and "<ETHx_IPy>" placeholders where possible.
-        static  = backends.resolve_vips  static, @vips, @n2a
-        dynamic = backends.resolve_vips dynamic, @vips, @n2a
+        # Replace all "<ETHx_IPy>", "<ETHx_VIPy>" and "<ETHx_EPy>" placeholders where possible.
+        static  = backends.resolve  static, *@ave
+        dynamic = backends.resolve dynamic, *@ave
 
         # NOTE: This ensures that backends can be added dynamically only to statically defined LBs.
         backends.combine static, dynamic


### PR DESCRIPTION
- Use the same IP/VIP/EP code/idea for HAProxy/LVS/DNS
- Do NOT parse ETHx_ALIASy variables (unsupported in VR)
- Stop pretending IP6 is supported (TODO)