### PR TITLE
F OpenNebula/one-apps#47: Implement READY_SCRIPT

### DIFF
--- a/context-linux/src/etc/one-context.d/net-99-report-ready
+++ b/context-linux/src/etc/one-context.d/net-99-report-ready
@@ -71,17 +71,47 @@ report_ready() {
     esac
 }
 
-while [ "$RETRY_COUNT" -gt 0 ] ; do
-    if [[ -n "$READY_SCRIPT" ]];then
-        if eval "$READY_SCRIPT";then
+is_base64() {
+    [[ $1 =~ ^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$ ]]
+}
+
+log_ready_error() {
+    echo "$1" failed to execute. Not reporting READY on attempt "$RETRY_COUNT" >&2
+    false # force fail for retry
+}
+
+if [ -n "$READY_SCRIPT_PATH" ]; then
+    if [ -e "$READY_SCRIPT_PATH" ]; then
+        ready_method() {
+            if "$READY_SCRIPT_PATH"; then
+                report_ready
+            else
+                log_ready_error "$READY_SCRIPT_PATH"
+            fi
+        }
+    else
+        echo "$READY_SCRIPT_PATH" does not exist >&2
+        exit 1
+    fi
+elif [ -n "$READY_SCRIPT" ]; then
+    # Can lead to butchering of simple non encoded commands, Ex. echo
+    is_base64 "$READY_SCRIPT" && READY_SCRIPT=$(echo "$READY_SCRIPT" | base64 -d)
+
+    ready_method() {
+        if (eval "$READY_SCRIPT"); then
             report_ready
         else
-            echo READY_SCRIPT "$READY_SCRIPT" failed to execute. Not reporting READY on attempt "$RETRY_COUNT" >&2
-            asdf &>/dev/null # force fail for retry
+            log_ready_error "READY_SCRIPT"
         fi
-    else
+    }
+else
+    ready_method() {
         report_ready
-    fi
+    }
+fi
+
+while [ "$RETRY_COUNT" -gt 0 ] ; do
+    ready_method
 
     # shellcheck disable=SC2181
     if [ "$?" = "0" ]; then

--- a/context-linux/src/etc/one-context.d/net-99-report-ready
+++ b/context-linux/src/etc/one-context.d/net-99-report-ready
@@ -76,7 +76,7 @@ while [ "$RETRY_COUNT" -gt 0 ] ; do
         if eval "$READY_SCRIPT";then
             report_ready
         else
-            echo READY_SCRIPT "$READY_SCRIPT" failed to execute. Not reporting READY >&2
+            echo READY_SCRIPT "$READY_SCRIPT" failed to execute. Not reporting READY on attempt "$RETRY_COUNT" >&2
             asdf &>/dev/null # force fail for retry
         fi
     else
@@ -85,6 +85,7 @@ while [ "$RETRY_COUNT" -gt 0 ] ; do
 
     # shellcheck disable=SC2181
     if [ "$?" = "0" ]; then
+        echo "Reported READY"
         exit 0
     fi
 

--- a/context-linux/src/etc/one-context.d/net-99-report-ready
+++ b/context-linux/src/etc/one-context.d/net-99-report-ready
@@ -43,7 +43,7 @@ else
     exit 1
 fi > /dev/null # this will not drop the error message which goes to stderr
 
-while [ "$RETRY_COUNT" -gt 0 ] ; do
+report_ready() {
     case "$_command" in
         curl)
             curl -X "PUT" "${ONEGATE_ENDPOINT}/vm" \
@@ -69,6 +69,19 @@ while [ "$RETRY_COUNT" -gt 0 ] ; do
             fi
             ;;
     esac
+}
+
+while [ "$RETRY_COUNT" -gt 0 ] ; do
+    if [[ -n "$READY_SCRIPT" ]];then
+        if eval "$READY_SCRIPT";then
+            report_ready
+        else
+            echo READY_SCRIPT "$READY_SCRIPT" failed to execute. Not reporting READY >&2
+            asdf &>/dev/null # force fail for retry
+        fi
+    else
+        report_ready
+    fi
 
     # shellcheck disable=SC2181
     if [ "$?" = "0" ]; then
@@ -79,4 +92,5 @@ while [ "$RETRY_COUNT" -gt 0 ] ; do
     sleep "${RETRY_WAIT_PERIOD}"
 done
 
+echo "Failed to report READY" >&2
 exit 1


### PR DESCRIPTION
- READY=YES reporting will now check if the READY_SCRIPT variable is defined. If it is, then its execution will be evaluated for READY reporting.
- Also a minor error logging addition in the end to explicitly mention net-99 failure.


Example runs

- First run is `READY_SCRIPT="echo simple_script"`
- Second run is `READY_SCRIPT="asdf"`

```log
"Jan 23 15:02:26 localhost daemon.info init: starting pid 2633, tty '/dev/tty1': '/sbin/getty 38400 tty1'\n" +
"Jan 23 15:02:26 localhost daemon.info init: starting pid 2634, tty '/dev/tty2': '/sbin/getty 38400 tty2'\n" +
"Jan 23 15:02:26 localhost daemon.info init: starting pid 2635, tty '/dev/tty3': '/sbin/getty 38400 tty3'\n" +
"Jan 23 15:02:26 localhost daemon.info init: starting pid 2636, tty '/dev/tty4': '/sbin/getty 38400 tty4'\n" +
"Jan 23 15:02:26 localhost daemon.info init: starting pid 2637, tty '/dev/tty5': '/sbin/getty 38400 tty5'\n" +
"Jan 23 15:02:26 localhost daemon.info init: starting pid 2638, tty '/dev/tty6': '/sbin/getty 38400 tty6'\n" +
"Jan 23 15:02:27 localhost auth.info sshd[2639]: Accepted publickey for root from 192.168.150.1 port 58056 ssh2: RSA SHA256:1Vjt0ahzsNYqV2Ch3WyWCRvovo6zzFQIzX99JLuJ7H0\n" +
"Jan 23 15:02:28 localhost user.info : info: guest-shutdown called, mode: powerdown\n" +
"Jan 23 15:02:28 localhost daemon.info init: starting pid 2646, tty '': '/sbin/openrc shutdown'\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop /usr/sbin/sshd\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop PID 2632\n" +
"Jan 23 15:02:28 localhost user.debug : Sending signal 15 to PID 2632\n" +
"Jan 23 15:02:28 localhost auth.info sshd[2632]: Received signal 15; terminating.\n" +
"Jan 23 15:02:28 localhost auth.info sshd[2639]: Exiting on signal 15\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop /usr/bin/qemu-ga\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop PID 2589\n" +
"Jan 23 15:02:28 localhost user.debug : Sending signal 15 to PID 2589\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop /usr/bin/vmtoolsd\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop PID 2561\n" +
"Jan 23 15:02:28 localhost daemon.err /etc/init.d/open-vm-tools[2746]: start-stop-daemon: no matching processes found\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop /usr/sbin/haveged\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop PID 1484\n" +
"Jan 23 15:02:28 localhost user.debug : Sending signal 15 to PID 1484\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop /usr/sbin/crond\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop PID 2535\n" +
"Jan 23 15:02:28 localhost user.debug : Sending signal 15 to PID 2535\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop /sbin/syslogd\n" +
"Jan 23 15:02:28 localhost user.debug : Will stop PID 1657\n" +
"Jan 23 15:02:28 localhost user.debug : Sending signal 15 to PID 1657\n" +
"Jan 23 15:02:28 localhost syslog.info syslogd exiting\n" +
"Jan 23 15:02:45 localhost syslog.info syslogd started: BusyBox v1.35.0\n" +
"Jan 23 15:02:45 localhost local3.info one-contextd: Started for type local \n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Acquiring lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Acquired lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Mounting CD-ROM /dev/sr0 on /var/run/one-context/mount.OpOCPe\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Found context /var/run/one-context/mount.OpOCPe/context.sh\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Comparing /var/run/one-context/context.sh.OffJPL and /var/run/one-context/context.sh.local for changes\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: New context with changes\n" +
"Jan 23 15:02:45 localhost local3.info one-contextd: Processing local scripts\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Script loc-04-run-dir: Starting ...\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Script loc-04-run-dir: Finished with exit code 0\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Script loc-05-grow-rootfs: Starting ...\n" +
"Jan 23 15:02:45 localhost local3.info one-contextd: Script loc-05-grow-rootfs output: NOCHANGE: partition 1 could only be grown by -33 [fudge=2048] resize2fs 1.46.6 (1-Feb-2023) The filesystem is already 261120 (1k) blocks long.  Nothing to do!\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Script loc-05-grow-rootfs: Finished with exit code 0\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Script loc-09-timezone: Starting ...\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Script loc-09-timezone: Finished with exit code 0\n" +
"Jan 23 15:02:45 localhost local3.debug one-contextd: Script loc-10-network: Starting ...\n" +
"Jan 23 15:02:46 localhost local3.info one-contextd: Script loc-10-network output: /etc/one-context.d/loc-10-network.d/netcfg-interfaces: line 371: [: -ge: unary operator expected\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-10-network: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-10-network-pci: Starting ...\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-10-network-pci: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-14-mount-swap: Starting ...\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-14-mount-swap: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-16-gen-env: Starting ...\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-16-gen-env: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-20-set-username-password: Starting ...\n" +
"Jan 23 15:02:46 localhost authpriv.info usermod[2109]: change user 'root' password\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-20-set-username-password: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-22-ssh_public_key: Starting ...\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-22-ssh_public_key: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-30-console: Starting ...\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-30-console: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-35-securetty: Starting ...\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Script loc-35-securetty: Finished with exit code 0\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Finished scripts processing\n" +
"Jan 23 15:02:46 localhost local3.info one-contextd: Done\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Unmounting /var/run/one-context/mount.OpOCPe\n" +
"Jan 23 15:02:46 localhost local3.debug one-contextd: Releasing lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:02:48 localhost local3.info one-contextd: Started for type network \n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Acquiring lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Acquired lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Mounting CD-ROM /dev/sr0 on /var/run/one-context/mount.JLDfPC\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Found context /var/run/one-context/mount.JLDfPC/context.sh\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Comparing /var/run/one-context/context.sh.daADoI and /var/run/one-context/context.sh.network for changes\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: New context with changes\n" +
"Jan 23 15:02:48 localhost local3.info one-contextd: Processing network scripts\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Script net-15-hostname: Starting ...\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Script net-15-hostname: Finished with exit code 0\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Script net-97-start-script: Starting ...\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Script net-97-start-script: Finished with exit code 0\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Script net-98-execute-scripts: Starting ...\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Script net-98-execute-scripts: Finished with exit code 0\n" +
"Jan 23 15:02:48 localhost local3.debug one-contextd: Script net-99-report-ready: Starting ...\n" +
"Jan 23 15:02:49 localhost local3.info one-contextd: Script net-99-report-ready output: simple_ready   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                  Dload  Upload   Total   Spent    Left  Speed ^M  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0^M100     9    0     0  100     9      0     14 --:--:-- --:--:-- --:--:--    14\n" +
"Jan 23 15:02:49 localhost local3.debug one-contextd: Script net-99-report-ready: Finished with exit code 0\n" +
"Jan 23 15:02:49 localhost local3.debug one-contextd: Finished scripts processing\n" +
"Jan 23 15:02:49 localhost local3.info one-contextd: Done\n" +
"Jan 23 15:02:49 localhost local3.debug one-contextd: Unmounting /var/run/one-context/mount.JLDfPC\n" +
"Jan 23 15:02:49 localhost local3.debug one-contextd: Releasing lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2493, tty '': '/sbin/openrc default'\n" +
"Jan 23 15:02:49 localhost cron.info crond[2541]: crond (busybox 1.35.0) started, log level 8\n" +
"Jan 23 15:02:49 localhost auth.info sshd[2635]: Server listening on 0.0.0.0 port 22.\n" +
"Jan 23 15:02:49 localhost auth.info sshd[2635]: Server listening on :: port 22.\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2639, tty '/dev/tty1': '/sbin/getty 38400 tty1'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2640, tty '/dev/tty2': '/sbin/getty 38400 tty2'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2641, tty '/dev/tty3': '/sbin/getty 38400 tty3'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2642, tty '/dev/tty4': '/sbin/getty 38400 tty4'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2643, tty '/dev/tty5': '/sbin/getty 38400 tty5'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2644, tty '/dev/tty6': '/sbin/getty 38400 tty6'\n" +
"Jan 23 15:02:50 localhost auth.info sshd[2645]: Accepted publickey for root from 192.168.150.1 port 50738 ssh2: RSA SHA256:1Vjt0ahzsNYqV2Ch3WyWCRvovo6zzFQIzX99JLuJ7H0\n"
      Report READY=YES with success on READY_SCRIPT
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2639, tty '/dev/tty1': '/sbin/getty 38400 tty1'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2640, tty '/dev/tty2': '/sbin/getty 38400 tty2'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2641, tty '/dev/tty3': '/sbin/getty 38400 tty3'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2642, tty '/dev/tty4': '/sbin/getty 38400 tty4'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2643, tty '/dev/tty5': '/sbin/getty 38400 tty5'\n" +
"Jan 23 15:02:49 localhost daemon.info init: starting pid 2644, tty '/dev/tty6': '/sbin/getty 38400 tty6'\n" +
"Jan 23 15:02:50 localhost auth.info sshd[2645]: Accepted publickey for root from 192.168.150.1 port 50738 ssh2: RSA SHA256:1Vjt0ahzsNYqV2Ch3WyWCRvovo6zzFQIzX99JLuJ7H0\n" +
"Jan 23 15:02:52 localhost user.info : info: guest-shutdown called, mode: powerdown\n" +
"Jan 23 15:02:52 localhost daemon.info init: starting pid 2653, tty '': '/sbin/openrc shutdown'\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop /usr/sbin/sshd\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop PID 2635\n" +
"Jan 23 15:02:52 localhost user.debug : Sending signal 15 to PID 2635\n" +
"Jan 23 15:02:52 localhost auth.info sshd[2635]: Received signal 15; terminating.\n" +
"Jan 23 15:02:52 localhost auth.info sshd[2645]: Exiting on signal 15\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop /usr/bin/qemu-ga\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop PID 2595\n" +
"Jan 23 15:02:52 localhost user.debug : Sending signal 15 to PID 2595\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop /usr/bin/vmtoolsd\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop PID 2567\n" +
"Jan 23 15:02:52 localhost daemon.err /etc/init.d/open-vm-tools[2753]: start-stop-daemon: no matching processes found\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop /usr/sbin/haveged\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop PID 1485\n" +
"Jan 23 15:02:52 localhost user.debug : Sending signal 15 to PID 1485\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop /usr/sbin/crond\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop PID 2541\n" +
"Jan 23 15:02:52 localhost user.debug : Sending signal 15 to PID 2541\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop /sbin/syslogd\n" +
"Jan 23 15:02:52 localhost user.debug : Will stop PID 1658\n" +
"Jan 23 15:02:52 localhost user.debug : Sending signal 15 to PID 1658\n" +
"Jan 23 15:02:52 localhost syslog.info syslogd exiting\n" +
"Jan 23 15:03:12 localhost syslog.info syslogd started: BusyBox v1.35.0\n" +
"Jan 23 15:03:12 localhost local3.info one-contextd: Started for type local \n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Acquiring lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Acquired lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Mounting CD-ROM /dev/sr0 on /var/run/one-context/mount.ILelGC\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Found context /var/run/one-context/mount.ILelGC/context.sh\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Comparing /var/run/one-context/context.sh.ADIngE and /var/run/one-context/context.sh.local for changes\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: New context with changes\n" +
"Jan 23 15:03:12 localhost local3.info one-contextd: Processing local scripts\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Script loc-04-run-dir: Starting ...\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Script loc-04-run-dir: Finished with exit code 0\n" +
"Jan 23 15:03:12 localhost local3.debug one-contextd: Script loc-05-grow-rootfs: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.info one-contextd: Script loc-05-grow-rootfs output: NOCHANGE: partition 1 could only be grown by -33 [fudge=2048] resize2fs 1.46.6 (1-Feb-2023) The filesystem is already 261120 (1k) blocks long.  Nothing to do!\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-05-grow-rootfs: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-09-timezone: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-09-timezone: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-10-network: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.info one-contextd: Script loc-10-network output: /etc/one-context.d/loc-10-network.d/netcfg-interfaces: line 371: [: -ge: unary operator expected\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-10-network: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-10-network-pci: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-10-network-pci: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-14-mount-swap: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-14-mount-swap: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-16-gen-env: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-16-gen-env: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-20-set-username-password: Starting ...\n" +
"Jan 23 15:03:13 localhost authpriv.info usermod[2109]: change user 'root' password\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-20-set-username-password: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-22-ssh_public_key: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-22-ssh_public_key: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-30-console: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-30-console: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-35-securetty: Starting ...\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Script loc-35-securetty: Finished with exit code 0\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Finished scripts processing\n" +
"Jan 23 15:03:13 localhost local3.info one-contextd: Done\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Unmounting /var/run/one-context/mount.ILelGC\n" +
"Jan 23 15:03:13 localhost local3.debug one-contextd: Releasing lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:03:15 localhost local3.info one-contextd: Started for type network \n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Acquiring lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Acquired lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Mounting CD-ROM /dev/sr0 on /var/run/one-context/mount.kKiMCP\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Found context /var/run/one-context/mount.kKiMCP/context.sh\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Comparing /var/run/one-context/context.sh.hgoFil and /var/run/one-context/context.sh.network for changes\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: New context with changes\n" +
"Jan 23 15:03:15 localhost local3.info one-contextd: Processing network scripts\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Script net-15-hostname: Starting ...\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Script net-15-hostname: Finished with exit code 0\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Script net-97-start-script: Starting ...\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Script net-97-start-script: Finished with exit code 0\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Script net-98-execute-scripts: Starting ...\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Script net-98-execute-scripts: Finished with exit code 0\n" +
"Jan 23 15:03:15 localhost local3.debug one-contextd: Script net-99-report-ready: Starting ...\n" +
"Jan 23 15:03:45 localhost local3.info one-contextd: Script net-99-report-ready output: /etc/one-context.d/net-99-report-ready: line 77: asdf: command not found READY_SCRIPT asdf failed to execute. Not reporting READY /etc/one-context.d/net-99-report-ready: line 77: asdf: command not found READY_SCRIPT asdf failed to execute. Not reporting READY /etc/one-context.d/net-99-report-ready: line 77: asdf: command not found READY_SCRIPT asdf failed to execute. Not reporting READY Failed to report READY\n" +
"Jan 23 15:03:45 localhost local3.err one-contextd: Script net-99-report-ready: Finished with exit code 1\n" +
"Jan 23 15:03:45 localhost local3.debug one-contextd: Finished scripts processing\n" +
"Jan 23 15:03:45 localhost local3.info one-contextd: Done\n" +
"Jan 23 15:03:45 localhost local3.debug one-contextd: Unmounting /var/run/one-context/mount.kKiMCP\n" +
"Jan 23 15:03:45 localhost local3.debug one-contextd: Releasing lock /var/run/one-context/one-context.lock\n" +
"Jan 23 15:03:45 localhost daemon.info init: starting pid 2496, tty '': '/sbin/openrc default'\n" +
"Jan 23 15:03:45 localhost cron.info crond[2544]: crond (busybox 1.35.0) started, log level 8\n" +
"Jan 23 15:03:45 localhost auth.info sshd[2639]: Server listening on 0.0.0.0 port 22.\n" +
"Jan 23 15:03:45 localhost auth.info sshd[2639]: Server listening on :: port 22.\n" +
"Jan 23 15:03:45 localhost daemon.info init: starting pid 2642, tty '/dev/tty1': '/sbin/getty 38400 tty1'\n" +
"Jan 23 15:03:45 localhost daemon.info init: starting pid 2643, tty '/dev/tty2': '/sbin/getty 38400 tty2'\n" +
"Jan 23 15:03:45 localhost daemon.info init: starting pid 2644, tty '/dev/tty3': '/sbin/getty 38400 tty3'\n" +
"Jan 23 15:03:45 localhost daemon.info init: starting pid 2645, tty '/dev/tty4': '/sbin/getty 38400 tty4'\n" +
"Jan 23 15:03:45 localhost daemon.info init: starting pid 2646, tty '/dev/tty5': '/sbin/getty 38400 tty5'\n" +
"Jan 23 15:03:45 localhost daemon.info init: starting pid 2647, tty '/dev/tty6': '/sbin/getty 38400 tty6'\n" +
"Jan 23 15:03:46 localhost auth.info sshd[2648]: Accepted publickey for root from 192.168.150.1 port 45076 ssh2: RSA SHA256:1Vjt0ahzsNYqV2Ch3WyWCRvovo6zzFQIzX99JLuJ7H0\n"
      Does not report READY=YES with fail on READY_SCRIPT

Finished in 1 minute 41.02 seconds (files took 0.7138 seconds to load)
7 examples, 0 failures

/var/lib/one
```

Closes #47 