### PR TITLE
M #: Correct serial console disabling on Amazon2, Alt and OpenSUSE

### DIFF
--- a/packer/alt/11-update-grub.sh
+++ b/packer/alt/11-update-grub.sh
@@ -11,11 +11,11 @@ rm -rf /etc/default/grub.d/
 # Drop unwanted.
 
 gawk -i inplace -f- /etc/sysconfig/grub2 <<'EOF'
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<quiet\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<splash\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<console=ttyS[^ ]*\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<earlyprintk=ttyS[^ ]*\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<crashkernel=[^ ]*\>/, "crashkernel=no") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<quiet\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<splash\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<console=ttyS[^ ]*\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<earlyprintk=ttyS[^ ]*\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<crashkernel=[^ ]*\>/, "crashkernel=no") }
 { print }
 EOF
 

--- a/packer/amazon/11-update-grub.sh
+++ b/packer/amazon/11-update-grub.sh
@@ -13,11 +13,11 @@ rm -rf /etc/default/grub.d/
 # Drop unwanted.
 
 gawk -f- /etc/default/grub >/etc/default/grub.new <<'EOF'
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<quiet\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<splash\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<console=ttyS[^ ]*\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<earlyprintk=ttyS[^ ]*\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<crashkernel=[^ ]*\>/, "crashkernel=no") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<quiet\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<splash\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<console=ttyS[^ ]*\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<earlyprintk=ttyS[^ ]*\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<crashkernel=[^ ]*\>/, "crashkernel=no") }
 { print }
 EOF
 mv /etc/default/grub{.new,}

--- a/packer/opensuse/11-update-grub.sh
+++ b/packer/opensuse/11-update-grub.sh
@@ -11,11 +11,11 @@ rm -rf /etc/default/grub.d/
 # Drop unwanted.
 
 gawk -i inplace -f- /etc/default/grub <<'EOF'
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<quiet\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<splash\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<console=ttyS[^ ]*\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<earlyprintk=ttyS[^ ]*\>/, "") }
-/^GRUB_CMDLINE_LINUX=/ { gsub(/\<crashkernel=[^ ]*\>/, "crashkernel=no") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<quiet\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<splash\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<console=ttyS[^ ]*\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<earlyprintk=ttyS[^ ]*\>/, "") }
+/^GRUB_CMDLINE_LINUX_DEFAULT=/ { gsub(/\<crashkernel=[^ ]*\>/, "crashkernel=no") }
 { print }
 EOF
 


### PR DESCRIPTION
The bash scripts were failing because the replacement was looking for GRUB_CMDLINE_LINUX but on those distros it was stated as GRUB_CMDLINE_LINUX_DEFAULT.

```
# If you change this file, run 'grub2-mkconfig -o /boot/grub2/grub.cfg' afterwards to update
# /boot/grub2/grub.cfg.

# Uncomment to set your own custom distributor. If you leave it unset or empty, the default
# policy is to determine the value from /etc/os-release
# GRUB_DISTRIBUTOR=""

GRUB_DEFAULT=0
GRUB_HIDDEN_TIMEOUT=0
GRUB_HIDDEN_TIMEOUT_QUIET=true
GRUB_TIMEOUT=0
GRUB_CMDLINE_LINUX_DEFAULT="rw systemd.show_status=1 console=ttyS0,115200 console=tty0 net.ifnames=0 quiet"
GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"

# Uncomment to automatically save last booted menu entry in GRUB2 environment
# variable `saved_entry'
#GRUB_SAVEDEFAULT="true"

# Uncomment to enable BadRAM filtering, modify to suit your needs
# This works with Linux (no patch required) and with any kernel that obtains
# the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
#GRUB_BADRAM="0x01234567,0xfefefefe,0x89abcdef,0xefefefef"

# Uncomment to disable graphical terminal (grub-pc only)
GRUB_TERMINAL="gfxterm"

# The resolution used on graphical terminal
# note that you can use only modes which your graphic card supports via VBE
# you can see them in real GRUB with the command `vbeinfo'
GRUB_GFXMODE=auto

# Uncomment if you don't want GRUB to pass"root=UUID=xxx"parameter to Linux
#GRUB_DISABLE_LINUX_UUID=true

# Uncomment to disable generation of recovery mode menu entries
#GRUB_DISABLE_RECOVERY="true"

# Uncomment to get a beep at grub start
#GRUB_INIT_TUNE="480 440 1"
GRUB_BACKGROUND=
GRUB_THEME=/boot/grub2/themes/openSUSE/theme.txt
GRUB_DISTRIBUTOR="openSUSE Leap 15.5"
```