### PR TITLE
Fix https://github.com/OpenNebula/one-apps/issues/75

### DIFF
--- a/context-linux/src/etc/one-context.d/loc-10-network.d/functions
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/functions
@@ -97,7 +97,7 @@ initialize_network()
     # To avoid clashes when running legacy network-scripts and
     # NetworkManager/networkd, we disable old-style networking
     # on Red Hats and enable later back only if needed.
-    if [ -d /etc/sysconfig/network-scripts/ ]; then
+    if [ -x /etc/sysconfig/network-scripts/ifup ]; then
         touch /etc/sysconfig/network
         sed -i -e '/^NETWORKING=/d' /etc/sysconfig/network
         echo 'NETWORKING=no' >>/etc/sysconfig/network


### PR DESCRIPTION
Use same method to detect presence if system is capable of `NETCFG_TYPE=scripts` as in `netcfg-scripts` - by checking for presence of `-x /etc/sysconfig/network-scripts/ifup`, not just directory `-d /etc/sysconfig/network-scripts/` which exists, because OS has put placeholder text file, describing that given configuration method is deprecated by OS.