### PR TITLE
M #: Remove temp hardcoded checksum

### DIFF
--- a/packer/opensuse/variables.pkr.hcl
+++ b/packer/opensuse/variables.pkr.hcl
@@ -27,9 +27,7 @@ variable "opensuse" {
   default = {
     "15" = {
       iso_url      = "https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2"
-      #iso_checksum = "file:https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-      #TEMP: checksum and images seems not synced
-      iso_checksum = "a160a84ec760a8beddaeb09579430851e43ac4c36620191305634a46de640c7a"
+      iso_checksum = "file:https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2.sha256"
     }
   }
 }


### PR DESCRIPTION
Seems it got synced again upstream. Build was failing.

```
==> null.null: Running local shell script: /tmp/packer-shell623232339
Build 'null.null' finished after 19 milliseconds 905 microseconds.
    qemu.opensuse: openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2 268.26 MiB / 268.26 MiB [==================================================================] 100.00% 12s
==> qemu.opensuse: Checksum did not match, removing /root/.cache/packer/ffd9670c3784907bfc347cd70eeaca43da56f4f9.iso
==> qemu.opensuse: error downloading ISO: [Checksums did not match for /root/.cache/packer/ffd9670c3784907bfc347cd70eeaca43da56f4f9.iso.
==> qemu.opensuse: Expected: a160a84ec760a8beddaeb09579430851e43ac4c36620191305634a46de640c7a
==> qemu.opensuse: Got: 752ffbd2cf187a2bf1f796f6dffac7ce4f7a9e870eb86ff29cec714c0a831be6
==> qemu.opensuse: *sha256.digest]
Build 'qemu.opensuse' errored after 16 seconds 713 milliseconds: error downloading ISO: [Checksums did not match for /root/.cache/packer/ffd9670c3784907bfc347cd70eeaca43da56f4f9.iso.
Expected: a160a84ec760a8beddaeb09579430851e43ac4c36620191305634a46de640c7a
Got: 752ffbd2cf187a2bf1f796f6dffac7ce4f7a9e870eb86ff29cec714c0a831be6
*sha256.digest]

==> Wait completed after 16 seconds 713 milliseconds

==> Some builds didn't complete successfully and had errors:
--> qemu.opensuse: error downloading ISO: [Checksums did not match for /root/.cache/packer/ffd9670c3784907bfc347cd70eeaca43da56f4f9.iso.
Expected: a160a84ec760a8beddaeb09579430851e43ac4c36620191305634a46de640c7a
Got: 752ffbd2cf187a2bf1f796f6dffac7ce4f7a9e870eb86ff29cec714c0a831be6
*sha256.digest]

==> Builds finished. The artifacts of successful builds are:
--> null.null: Did not export anything. This is the null builder
qemu-img: Could not open 'build/opensuse15/opensuse15': Could not open 'build/opensuse15/opensuse15': No such file or directory
[INFO] Packer opensuse15 done
```

