### PR TITLE
B #132: Sanitize/Check valid IPv4s

### DIFF
--- a/context-linux/src/etc/one-context.d/loc-10-network.d/functions
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/functions
@@ -619,7 +619,7 @@ is_link_local() {
 get_onegate_ip() {
 	if [[ -n $ONEGATE_ENDPOINT ]]; then
 		# Regular expression to match an IPv4 address
-		ipv4_regex="([0-9]{1,3}\.){3}[0-9]{1,3}"
+		ipv4_regex="(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))"
 
 		export onegate_host=$(echo "$ONEGATE_ENDPOINT" | grep -oE "$ipv4_regex")
 	fi
@@ -627,4 +627,8 @@ get_onegate_ip() {
 
 missing_onegate_proxy_route() {
     is_link_local "$onegate_host" && [[ $onegate_proxy_route_missing == "yes" ]]
+}
+
+valid_ipv4() {
+  [[ -n "$1" && "$1" =~ ^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$ ]]
 }

--- a/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
@@ -149,7 +149,7 @@ iface ${dev} inet static
   netmask ${mask}
 EOT
 
-    if [ -n "$gateway" ]; then
+    if valid_ipv4 $gateway; then
         echo "  gateway ${gateway}"
 
         if [ -n "$metric" ]; then

--- a/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
@@ -109,7 +109,7 @@ EOT
 
     echo "[Route]"
 
-    if [ -n "$gateway" ]; then
+    if valid_ipv4 $gateway; then
         echo "Gateway=${gateway}"
 
         if [ -n "$metric" ]; then

--- a/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-nm
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-nm
@@ -120,7 +120,7 @@ gen_iface_conf()
 {
     nmcli con mod "${dev}" ipv4.method manual ipv4.addresses "${ip}/${cidr}"
 
-    if [ -n "$gateway" ]; then
+    if valid_ipv4 $gateway; then
         nmcli con mod "${dev}" ipv4.gateway "${gateway}"
     else
         nmcli con mod "${dev}" ipv4.gateway ""


### PR DESCRIPTION
If a default gateway is an invalid IP (or a space character) it leads to an error. Also, the `ONEGATE_ENDPOINT` regex has been modified.