### PR TITLE
M#-: Updates amazon2 base image and sets ruby3.0 version

### DIFF
--- a/packer/amazon/10-upgrade-distro.sh.2
+++ b/packer/amazon/10-upgrade-distro.sh.2
@@ -15,4 +15,8 @@ yum upgrade -y util-linux
 # Ensure packages needed for post-processing scripts do exist.
 yum install -y curl gawk grep jq sed
 
+# Install ruby 3.0 as is also required for context cloud-init parsing
+amazon-linux-extras enable ruby3.0
+yum install -y ruby
+
 sync

--- a/packer/amazon/variables.pkr.hcl
+++ b/packer/amazon/variables.pkr.hcl
@@ -27,8 +27,8 @@ variable "amazon" {
   default = {
     "2" = {
       # navigate via https://cdn.amazonlinux.com/os-images/latest/kvm/
-      iso_url      = "https://cdn.amazonlinux.com/os-images/2.0.20231101.0/kvm/amzn2-kvm-2.0.20231101.0-x86_64.xfs.gpt.qcow2"
-      iso_checksum = "file:https://cdn.amazonlinux.com/os-images/2.0.20231101.0/kvm/SHA256SUMS"
+      iso_url      = "https://cdn.amazonlinux.com/os-images/2.0.20241031.0/kvm/amzn2-kvm-2.0.20241031.0-x86_64.xfs.gpt.qcow2"
+      iso_checksum = "file:https://cdn.amazonlinux.com/os-images/2.0.20241031.0/kvm/SHA256SUMS"
     }
     "2023" = {
       # navigate via https://cdn.amazonlinux.com/al2023/os-images/2023.4.20240513.0/


### PR DESCRIPTION
We found that our cloud-init contextualization script fails parsing the cloud-config YAML data set in USER_DATA due to the psych version that comes by default in ruby2.0. 

We updated the amazon linux 2 base image and installed ruby3.0 in order to solve those problems. 

Related with https://github.com/OpenNebula/one-apps/pull/130 