### PR TITLE
B#150: Fix authorization of standard SSH keys in context-windows

### DIFF
--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -1333,7 +1333,7 @@ function authorizeSSHKeyStandard {
     # prepare .ssh folder
     $sshFolderPath = "$userProfilePath\.ssh"
     if ( !(Test-Path $sshFolderPath)) {
-        logmsg "- Creating .ssh folder"
+        logmsg "- Creating .ssh folder in $userProfilePath"
         New-Item -Force -ItemType Directory -Path $sshFolderPath | Out-Null
         if ($?) {
             logsuccess

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -1334,7 +1334,7 @@ function authorizeSSHKeyStandard {
     $sshFolderPath = "$userProfilePath\.ssh"
     if ( !(Test-Path $sshFolderPath)) {
         logmsg "- Creating .ssh folder"
-        New-Item -Force -ItemType Directory -Path $sshFolderPath
+        New-Item -Force -ItemType Directory -Path $sshFolderPath | Out-Null
         if ($?) {
             logsuccess
         }

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -1297,13 +1297,13 @@ function authorizeSSHKeyAdmin {
 }
 
 function disableSharedAdminSSHKeys {
-    logmsg "- Disabling use of default shared admins_authorized_keys for Administrators group"
     $cfgtoRemoveRegex = ('Match Group administrators\r?\n' + 
                         ' {7}AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys(?:\r?\n)')
     $sshdConfigPath = "$env:PROGRAMDATA\ssh\sshd_config"
     $currentConfig = Get-Content $sshdConfigPath -Raw
     if ($currentConfig -match $cfgtoRemoveRegex) {
         $updatedConfig = $currentConfig -replace $cfgtoRemoveRegex
+        logmsg "- Disabling use of default shared admins_authorized_keys for Administrators group"
         Set-Content -Path $sshdConfigPath -Value $updatedConfig
         if ($?) {
             logsuccess

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -1296,16 +1296,58 @@ function authorizeSSHKeyAdmin {
 
 }
 
+function disableSharedAdminSSHKeys {
+    logmsg "- Disabling use of default shared admins_authorized_keys for Administrators group"
+    $cfgtoRemoveRegex = ('Match Group administrators\r?\n' + 
+                        ' {7}AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys(?:\r?\n)')
+    $sshdConfigPath = "$env:PROGRAMDATA\ssh\sshd_config"
+    $currentConfig = Get-Content $sshdConfigPath -Raw
+    if ($currentConfig -match $cfgtoRemoveRegex) {
+        $updatedConfig = $currentConfig -replace $cfgtoRemoveRegex
+        Set-Content -Path $sshdConfigPath -Value $updatedConfig
+        if ($?) {
+            logsuccess
+        } else {
+            logfail
+        }
+        $sshdService = Get-Service -Name sshd -ErrorAction SilentlyContinue
+        if ($sshdService.Status -eq "Running") {
+            Restart-Service $sshdService
+        }
+    }
+}
+
 function authorizeSSHKeyStandard {
     param (
-        $authorizedKeys
+        $authorizedKeys,
+        $username
     )
+    
+    # Check if user profile directory exists
+    $userProfilePath = "$env:systemdrive\Users\$username"
+    if ( !(Test-Path $userProfilePath)) {
+        logmsg "  ... Failed (Userprofile directory $userProfilePath does not exists)"
+        return
+    }
+    
+    # prepare .ssh folder
+    $sshFolderPath = "$userProfilePath\.ssh"
+    if ( !(Test-Path $sshFolderPath)) {
+        logmsg "- Creating .ssh folder"
+        New-Item -Force -ItemType Directory -Path $sshFolderPath
+        if ($?) {
+            logsuccess
+        }
+        else {
+            logfail
+            return
+        }
+    }
 
-    $authorizedKeysPath = "$env:USERPROFILE\.ssh"
-
-    New-Item -Force -ItemType Directory -Path $authorizedKeysPath
-    Set-Content $authorized_keys_path $authorizedKeys
-
+    # write the keys
+    $authorizedKeysFilePath = "$userProfilePath\.ssh\authorized_keys"
+    logmsg "- Writing key to $authorizedKeysFilePath"
+    Set-Content -Path $authorizedKeysFilePath -Value $authorizedKeys
     if ($?) {
         logsuccess
     }
@@ -1317,13 +1359,15 @@ function authorizeSSHKeyStandard {
 function authorizeSSHKey {
     param (
         $authorizedKeys,
-        $winadmin
+        $winadmin,
+        $username
     )
 
     logmsg "* Authorizing SSH_PUBLIC_KEY: ${authorizedKeys}"
 
     if ($winadmin -ieq "no") {
-        authorizeSSHKeyStandard $authorizedKeys
+        disableSharedAdminSSHKeys
+        authorizeSSHKeyStandard $authorizedKeys $username
     }
     else {
         authorizeSSHKeyAdmin $authorizedKeys
@@ -1388,7 +1432,7 @@ do {
     configureNetwork $context
     renameComputer $context
     runScripts $context $contextPaths
-    authorizeSSHKey $context["SSH_PUBLIC_KEY"] $context["WINADMIN"]
+    authorizeSSHKey $context["SSH_PUBLIC_KEY"] $context["WINADMIN"] $context["USERNAME"]
     reportReady $context $contextPaths.contextLetter
 
     # Save the 'applied' context.sh checksum for the next recontextualization


### PR DESCRIPTION
Resolves #150 and adds a change of default SSH configuration for Windows from shared authorized SSH keys for all Administrator accounts to per-user SSH keys if context variable **WINADMIN** is set to **NO**

**Known issues**
- SSH key is not added when user does not yet have a profile directory (did not login for the first time)
