### PR TITLE
Fix allow inbound echo requests + configure SSH keys only when needed

### DIFF
--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -907,13 +907,13 @@ function enableRemoteDesktop() {
 function enablePing() {
     logmsg "* Enabling Ping"
     #Create firewall manager object
-    New-Object -com hnetcfg.fwmgr
-
+    $fwmgr = New-Object -ComObject HNetCfg.FwMgr
+    
     # Get current profile
-    $pro = $fwmgcalPolicy.CurrentProfile
-
+    $profile = $fwmgr.LocalPolicy.CurrentProfile
+    
     logmsg "- Enable Allow Inbound Echo Requests"
-    $ret = $pro.IcmpSettings.AllowInboundEchoRequest = $true
+    $ret = $profile.IcmpSettings.AllowInboundEchoRequest = $true
     If ($ret) {
         logmsg "  ... Success"
     }
@@ -1322,13 +1322,17 @@ function authorizeSSHKey {
 
     logmsg "* Authorizing SSH_PUBLIC_KEY: ${authorizedKeys}"
 
-    if ($winadmin -ieq "no") {
-        authorizeSSHKeyStandard $authorizedKeys
+    if (${authorizedKeys} -ne $null -and ${authorizedKeys} -ne "") {
+        if ($winadmin -ieq "no") {
+            authorizeSSHKeyStandard $authorizedKeys
+        }
+        else {
+            authorizeSSHKeyAdmin $authorizedKeys
+        }
     }
     else {
-        authorizeSSHKeyAdmin $authorizedKeys
+        logmsg "- No SSH_PUBLIC_KEY provided, skipping"
     }
-
 }
 
 ################################################################################


### PR DESCRIPTION
Two small adjustments:

1) Allowing ICMP requests did not work because the variable `$fwmgcalPolicy` was not defined. As a result, executing it produced the following error message:

```powershell
[2024-12-05 13:44 +01:00] * Enabling Ping

LocalPolicy        : System.__ComObject
CurrentProfileType : 1

[2024-12-05 13:44 +01:00] - Enable Allow Inbound Echo Requests
The property 'AllowInboundEchoRequest' cannot be found on this object. Verify that the property exists and can be set.
At C:\Program Files (x86)\OpenNebula\context.ps1:916 char:12
+     $ret = $pro.IcmpSettings.AllowInboundEchoRequest = $true
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : PropertyNotFound
The property 'AllowInboundEchoRequest' cannot be found on this object. Verify that the property exists and can be set.
At C:\Program Files (x86)\OpenNebula\context.ps1:916 char:12
+     $ret = $pro.IcmpSettings.AllowInboundEchoRequest = $true
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : PropertyNotFound

[2024-12-05 13:44 +01:00]   ... Failed
```

2) When the variable `$context["SSH_PUBLIC_KEY"]` is empty, it is unnecessary to call the functions any further.