### PR TITLE
Add ability to enable SSH in context-windows

### DIFF
--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -904,6 +904,46 @@ function enableRemoteDesktop() {
     Write-Host "`r`n" -NoNewline
 }
 
+function enableSSH() {
+    logmsg "* Enabling SSH"
+    # Get sshd service
+    $serviceName = "sshd"
+    $sshdService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+    
+    # Check if service is present
+    if ($sshdService) {
+        # Service is running and automatic start is enabled
+        if ($sshdService.StartType -eq "Automatic" -and $sshdService.Status -eq "Running") {
+            logmsg " ... Success (Service is already enabled and running )"
+            return
+        }
+        # Enable autostart
+        if ($sshdService.StartType -ne "Automatic") {
+            logmsg "- Enabling automatic start for SSH service"
+            Set-Service -Name $serviceName -StartupType Automatic
+            if ($?) {
+                logsuccess
+            } else {
+                logfail
+                return
+            }
+        }
+        # Start service
+        if ($sshdService.Status -ne "Running") {
+            logmsg "- Starting SSH service"
+        Start-Service -Name $serviceName
+        if ($?) {
+            logsuccess
+        } else {
+            logfail
+        }
+    }
+    } else {
+        # OpenSSH.Server feature is not installed
+        logmsg " ... Failed (OpenSSH Server is not installed)"
+    }
+}
+
 function enablePing() {
     logmsg "* Enabling Ping"
     #Create firewall manager object

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -1424,6 +1424,7 @@ do {
     setTimeZone $context
     addLocalUser $context
     enableRemoteDesktop
+    enableSSH
     enablePing
     configureNetwork $context
     renameComputer $context


### PR DESCRIPTION
**Description**

I have added the **enableSSH** function to the Windows contextualization package. I'm also calling this function from the contextualization loop.

This function:
- Checks if **sshd** service is present (OpenSSH.Server capability is installed, or [another SSH server](https://github.com/PowerShell/openssh-portable) is installed).
- If the service is not present, the function ends gracefully
- If the service is running and autostart is enabled, nothing is changed
- If the service is not running, it will be started
- If the service is not set to start automatically, it will be started

Function logs the following events:
- The sshd service is not present
- The sshd service is started and set to start automatically
- The sshd service was started by the function
- The sshd service was set to start automatically by the function

**Things to consider**
- Add check for new contextualization variable **ENABLE_SSH = "NO"**, so users can disable this behaviour
- Call the function only if SSH needs to be contextualized ( #152 )