### PR TITLE
F#164: Add support for AlmaLinux OS 10 and AlmaLinux Kitten OS 10

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -38,6 +38,7 @@ $(shell mkdir -p ${DIR_BUILD} ${DIR_EXPORT})
 LINUX_CONTEXT_PACKAGES := one-context_${VERSION}-${RELEASE}.deb \
     one-context-${VERSION}-${RELEASE}.el8.noarch.rpm \
     one-context-${VERSION}-${RELEASE}.el9.noarch.rpm \
+    one-context-${VERSION}-${RELEASE}.el10.noarch.rpm \
     one-context-${VERSION}-${RELEASE}.fc.noarch.rpm \
     one-context-${VERSION}-${RELEASE}.amzn2.noarch.rpm \
     one-context-${VERSION}-${RELEASE}.amzn2023.noarch.rpm \

--- a/context-linux/generate-all.sh
+++ b/context-linux/generate-all.sh
@@ -3,7 +3,7 @@
 set -e
 
 export DATE=$(date +%Y%m%d)
-TARGETS='el8 el9 fc amzn2 amzn2023 alt suse deb alpine freebsd iso'
+TARGETS='el8 el9 el10 fc amzn2 amzn2023 alt suse deb alpine freebsd iso'
 
 for TARGET in $TARGETS; do
 	TARGET="${TARGET}" ./generate.sh

--- a/context-linux/targets.sh
+++ b/context-linux/targets.sh
@@ -64,6 +64,22 @@ case "${TARGET}" in
         POSTUP=${POSTUP:-pkg/postupgrade}
         ;;
 
+    'el10')
+        NAME=${NAME:-one-context}
+        RELSUFFIX=${RELSUFFIX:-.el10}
+        TYPE=${TYPE:-rpm}
+        TAGS=${TAGS:-linux rpm systemd one}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server qemu-guest-agent gawk virt-what}
+        RECOMMENDS=${RECOMMENDS:-open-vm-tools}
+        PROVIDES=${PROVIDES:-}
+        REPLACES=${REPLACES:-cloud-init}
+        CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
+        POSTIN=${POSTINST:-pkg/postinstall}
+        PREUN=${PREUN:-pkg/preuninstall}
+        POSTUN=${POSTUN:-pkg/postuninstall}
+        POSTUP=${POSTUP:-pkg/postupgrade}
+        ;;
+
     'fc')
         NAME=${NAME:-one-context}
         RELSUFFIX=${RELSUFFIX:-.fc}


### PR DESCRIPTION
The official OpenNebula images for AlmaLinux OS Kitten 10 already available with this patch:

- x86_64: https://kitten.repo.almalinux.org/10-kitten/cloud/x86_64/images/
- AArch64: https://kitten.repo.almalinux.org/10-kitten/cloud/aarch64/images/
- x86_64_v2: https://kitten.repo.almalinux.org/10-kitten/cloud/x86_64_v2/images/

fixes #164 