### PR TITLE
b-#: Pins ubuntu 2204 version for avoiding kernel bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,18 +32,22 @@ packer-service_Harbor: packer-ubuntu2204 ${DIR_EXPORT}/service_Harbor.qcow2
 packer-service_MinIO: packer-ubuntu2204 ${DIR_EXPORT}/service_MinIO.qcow2
 	@${INFO} "Packer service_MinIO done"
 
-packer-service_OneKE: packer-ubuntu2204 ${DIR_EXPORT}/service_OneKE.qcow2
+packer-service_OneKE: packer-ubuntu2204oneke ${DIR_EXPORT}/service_OneKE.qcow2 ${DIR_EXPORT}/service_OneKE_storage.qcow2
 	@${INFO} "Packer service_OneKE done"
 
 # airgapped version
 packer-service_OneKEa: PKR_VAR_airgapped := YES
-packer-service_OneKEa: packer-ubuntu2204 ${DIR_EXPORT}/service_OneKEa.qcow2
+packer-service_OneKEa: packer-ubuntu2204oneke ${DIR_EXPORT}/service_OneKEa.qcow2 ${DIR_EXPORT}/service_OneKE_storage.qcow2
 	@${INFO} "Packer service_OneKEa done"
 
 packer-service_Ray: packer-ubuntu2204 ${DIR_EXPORT}/service_Ray.qcow2
 	@${INFO} "Packer service_Ray done"
 
 # run packer build for given distro or service
+${DIR_EXPORT}/service_OneKE_storage.qcow2:
+	qemu-img create -f qcow2 ${DIR_EXPORT}/service_OneKE_storage.qcow2 10G
+	@${INFO} "Packer service_OneKE_storage done"
+
 ${DIR_EXPORT}/%.qcow2: $(patsubst %, context-linux/out/%, $(LINUX_CONTEXT_PACKAGES))
 	$(eval DISTRO_NAME := $(shell echo ${*} | sed 's/[0-9].*//'))
 	$(eval DISTRO_VER  := $(shell echo ${*} | sed 's/^.[^0-9]*\(.*\)/\1/'))

--- a/Makefile.config
+++ b/Makefile.config
@@ -18,7 +18,7 @@ DISTROS := alma8 alma8.aarch64 alma9 alma9.aarch64 \
            ol8 ol9 \
            opensuse15 \
            rocky8 rocky9 \
-           ubuntu2004 ubuntu2004min ubuntu2204 ubuntu2204.aarch64 ubuntu2204oneke ubuntu2204oneke.aarch64 ubuntu2204min ubuntu2204min.aarch64 ubuntu2404 ubuntu2404.aarch64 ubuntu2404min ubuntu2404min.aarch64
+           ubuntu2004 ubuntu2004min ubuntu2204 ubuntu2204.aarch64 ubuntu2204oneke ubuntu2204min ubuntu2204min.aarch64 ubuntu2404 ubuntu2404.aarch64 ubuntu2404min ubuntu2404min.aarch64
 
 SERVICES := service_Wordpress service_VRouter service_OneKE service_OneKEa service_Harbor service_MinIO service_Ray service_example
 

--- a/Makefile.config
+++ b/Makefile.config
@@ -18,7 +18,7 @@ DISTROS := alma8 alma8.aarch64 alma9 alma9.aarch64 \
            ol8 ol9 \
            opensuse15 \
            rocky8 rocky9 \
-           ubuntu2004 ubuntu2004min ubuntu2204 ubuntu2204.aarch64 ubuntu2204min ubuntu2204min.aarch64 ubuntu2404 ubuntu2404.aarch64 ubuntu2404min ubuntu2404min.aarch64
+           ubuntu2004 ubuntu2004min ubuntu2204 ubuntu2204.aarch64 ubuntu2204oneke ubuntu2204oneke.aarch64 ubuntu2204min ubuntu2204min.aarch64 ubuntu2404 ubuntu2404.aarch64 ubuntu2404min ubuntu2404min.aarch64
 
 SERVICES := service_Wordpress service_VRouter service_OneKE service_OneKEa service_Harbor service_MinIO service_Ray service_example
 

--- a/packer/service_OneKE/OneKE.pkr.hcl
+++ b/packer/service_OneKE/OneKE.pkr.hcl
@@ -18,7 +18,7 @@ source "qemu" "OneKE" {
   memory      = 2048
   accelerator = "kvm"
 
-  iso_url      = "export/ubuntu2204.qcow2"
+  iso_url      = "export/ubuntu2204oneke.qcow2"
   iso_checksum = "none"
 
   headless = var.headless

--- a/packer/ubuntu/variables.pkr.hcl
+++ b/packer/ubuntu/variables.pkr.hcl
@@ -30,10 +30,6 @@ variable "ubuntu" {
       iso_url      = "https://cloud-images.ubuntu.com/releases/22.04/release-20241206/ubuntu-22.04-server-cloudimg-amd64.img"
       iso_checksum = "file:https://cloud-images.ubuntu.com/releases/22.04/release-20241206/SHA256SUMS"
     }
-    "2204oneke.aarch64" = {
-      iso_url      = "https://cloud-images.ubuntu.com/releases/22.04/release-20241206/ubuntu-22.04-server-cloudimg-arm64.img"
-      iso_checksum = "file:https://cloud-images.ubuntu.com/releases/22.04/release-20241206/SHA256SUMS"
-    }
 
     "2204" = {
       iso_url      = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"

--- a/packer/ubuntu/variables.pkr.hcl
+++ b/packer/ubuntu/variables.pkr.hcl
@@ -25,6 +25,16 @@ variable "ubuntu" {
   type = map(map(string))
 
   default = {
+
+    "2204oneke" = {
+      iso_url      = "https://cloud-images.ubuntu.com/releases/22.04/release-20241206/ubuntu-22.04-server-cloudimg-amd64.img"
+      iso_checksum = "file:https://cloud-images.ubuntu.com/releases/22.04/release-20241206/SHA256SUMS"
+    }
+    "2204oneke.aarch64" = {
+      iso_url      = "https://cloud-images.ubuntu.com/releases/22.04/release-20241206/ubuntu-22.04-server-cloudimg-arm64.img"
+      iso_checksum = "file:https://cloud-images.ubuntu.com/releases/22.04/release-20241206/SHA256SUMS"
+    }
+
     "2204" = {
       iso_url      = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
       iso_checksum = "file:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"


### PR DESCRIPTION
We pin the ubuntu22.04 version due to a kernel bug in the current version that affects kube-proxy deployment in OneKE 1.31.

Also add a makefile recipe for creating the OneKE storage disk image.

More info: https://github.com/rancher/rke2/issues/7438