### PR TITLE
B #-: Alpine: Improve one-context dependency

### DIFF
--- a/context-linux/pkg/postinstall
+++ b/context-linux/pkg/postinstall
@@ -44,7 +44,12 @@ elif which update-rc.d >/dev/null 2>&1; then
 
 elif which rc-update >/dev/null 2>&1; then
     for S in ${SERVICES}; do
-        rc-update add "${S}" boot >/dev/null 2>&1
+        # one-context weak dependency on 'net' only work in same run level (default)
+        if [ "${S}" = 'one-context' ]; then
+            rc-update add "${S}" default >/dev/null 2>&1
+        else
+            rc-update add "${S}" boot >/dev/null 2>&1
+        fi
     done
 
     # Add crontab action for 1min schedules

--- a/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
@@ -368,7 +368,7 @@ gen_network_configuration()
     # since Ubuntu 22.04 and newer networkd systemd-networkd-wait-online
     # started to timeout+fail with NETCFG_TYPE='interfaces'
     _networkd_version=$(networkctl --version 2>/dev/null | head -1 | awk '{print $2}')
-    if [ $_networkd_version -ge 249 ]; then
+    if [ -n "$_networkd_version" ] && [ $_networkd_version -ge 249 ]; then
         systemctl disable --now systemd-networkd-wait-online.service
     fi
 

--- a/packer/alpine/98-collect-garbage.sh
+++ b/packer/alpine/98-collect-garbage.sh
@@ -6,6 +6,7 @@ exec 1>&2
 set -eux -o pipefail
 
 apk del cloud-init
+find /etc/runlevels/ -name 'cloud-init*' -delete
 
 rm -f /etc/motd
 


### PR DESCRIPTION
Put one-context to `default` run level.

Mainly due to reporting READY='YES' to onegate, one-context has weak
dependency on networking (`use net`) , this only works within the
same run levels.

+ cleanup cloud-init leftovers
+ suppress harmless error msg