### PR TITLE
M #-: Reformat Windows context script 

### DIFF
--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -858,7 +858,7 @@ function Rename-Computer {
         Write-LogMessage "- Current: $currentHostname"
         Write-LogMessage "- Context: $contextHostname"
     }
-    ElseIf ($contextHostname -ne $currentHostname) {
+    elseif ($contextHostname -ne $currentHostname) {
 
         # the current_name does not match the context_name, rename the computer
 
@@ -1117,7 +1117,7 @@ function Invoke-ScriptSetExecution {
     Write-Host "`r`n" -NoNewline
 }
 
-function Resize-Partition {
+function Resize-SinglePartition {
     param (
         $Disk,
         $Part
@@ -1183,7 +1183,7 @@ function Resize-PartitionSet {
             else {
                 Write-LogMessage "- Extend Disk: $($disk.diskId) / Part: $partId"
             }
-            Resize-Partition $disk.diskId $partId
+            Resize-SinglePartition $disk.diskId $partId
         }
     }
 }
@@ -1308,7 +1308,7 @@ function Dismount-ContextCD {
     }
 }
 
-function Remove-File($file) {
+function Remove-File {
     param (
         $File
     )

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -26,25 +26,24 @@
 # Functions
 ################################################################################
 
-function logmsg($message) {
+function Write-LogMessage {
+    param (
+        $Message
+    )
     # powershell 4 does not automatically add newline in the transcript so we
     # workaround it by adding it explicitly and using the NoNewline argument
     # we ensure that it will not be added twice
-    Write-Host "[$(Get-Date -Format 'yyyy-MM-dd HH:mm K')] $message`r`n" -NoNewline
+    Write-Host "[$(Get-Date -Format 'yyyy-MM-dd HH:mm K')] $Message`r`n" -NoNewline
 }
 
-function logsuccess {
-    logmsg "  ... Success"
-}
-function logfail {
-    logmsg "  ... Failed"
-}
-
-function getContext($file) {
+function Get-ContextData {
+    param (
+        $File
+    )
 
     # TODO: Improve regexp for multiple SSH keys on SSH_PUBLIC_KEY
     $context = @{}
-    switch -regex -file $file {
+    switch -regex -file $File {
         "^([^=]+)='(.+?)'$" {
             $name, $value = $matches[1..2]
             $context[$name] = $value
@@ -53,20 +52,29 @@ function getContext($file) {
     return $context
 }
 
-function envContext($context) {
-    ForEach ($h in $context.GetEnumerator()) {
+function Set-EnvironmentContext {
+    param (
+        $Context
+    )
+    foreach ($h in $Context.GetEnumerator()) {
         $name = "Env:" + $h.Name
         Set-Item $name $h.Value
     }
 }
 
-function contextChanged($file, $last_checksum) {
-    $new_checksum = Get-FileHash -Algorithm SHA256 $file
-    $ret = $last_checksum.Hash -ne $new_checksum.Hash
-    return $ret
+function Test-ContextChanged {
+    param (
+        $File,
+        $LastChecksum
+    )
+    $newChecksum = Get-FileHash -Algorithm SHA256 $File
+    return $LastChecksum.Hash -ne $newChecksum.Hash
 }
 
-function waitForContext($checksum) {
+function Wait-ForContext {
+    param (
+        $Checksum
+    )
     # This object will be set and returned at the end
     $contextPaths = New-Object PsObject -Property @{
         contextScriptPath     = $null
@@ -148,12 +156,12 @@ function waitForContext($checksum) {
         if (![string]::IsNullOrEmpty($contextPaths.contextPath) -and (Test-Path $contextPaths.contextPath)) {
 
             # Context must differ
-            if (contextChanged $contextPaths.contextPath $checksum) {
+            if (Test-ContextChanged $contextPaths.contextPath $Checksum) {
                 Break
             }
         }
 
-        cleanup $contextPaths
+        Remove-Context $contextPaths
 
         Write-Host "`r`n" -NoNewline
         Start-Sleep -Seconds $sleep
@@ -168,13 +176,16 @@ function waitForContext($checksum) {
     return $contextPaths
 }
 
-function addLocalUser($context) {
+function Add-LocalUser {
+    param (
+        $Context
+    )
     # Create new user
-    $username = $context["USERNAME"]
-    $password = $context["PASSWORD"]
-    $password64 = $context["PASSWORD_BASE64"]
+    $username = $Context["USERNAME"]
+    $password = $Context["PASSWORD"]
+    $password64 = $Context["PASSWORD_BASE64"]
 
-    If ($password64) {
+    if ($password64) {
         $password = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($password64))
     }
 
@@ -189,26 +200,26 @@ function addLocalUser($context) {
                 Get-Unique -AsString)
         }
 
-        logmsg "* Creating Account for $username"
+        Write-LogMessage "* Creating Account for $username"
 
         $ADSI = [adsi]$ConnectionString
 
         if (!([ADSI]::Exists("WinNT://$computerName/$username"))) {
             # User does not exist, Create the User
-            logmsg "- Creating account"
+            Write-LogMessage "- Creating account"
             $user = $ADSI.Create("user", $username)
             $user.setPassword($password)
             $user.SetInfo()
         }
         else {
             # User exists, Set Password
-            logmsg "- Setting Password"
+            Write-LogMessage "- Setting Password"
             $admin = [ADSI]"WinNT://$env:computername/$username"
             $admin.psbase.invoke("SetPassword", $password)
         }
 
         # Set Password to Never Expire
-        logmsg "- Setting password to never expire"
+        Write-LogMessage "- Setting password to never expire"
         $admin = [ADSI]"WinNT://$env:computername/$username"
         $admin.UserFlags.value = $admin.UserFlags.value -bor 0x10000
         $admin.CommitChanges()
@@ -220,10 +231,10 @@ function addLocalUser($context) {
             Where-Object { $_.SID -like "S-1-5-32-544" } |
             Select-Object -ExpandProperty Name)
 
-        ForEach ($grp in $groups) {
+        foreach ($grp in $groups) {
 
             # Make sure the Group exists
-            If ([ADSI]::Exists("WinNT://$computerName/$grp,group")) {
+            if ([ADSI]::Exists("WinNT://$computerName/$grp,group")) {
 
                 # Check if the user is a Member of the Group
                 $group = [ADSI] "WinNT://$computerName/$grp,group"
@@ -235,13 +246,13 @@ function addLocalUser($context) {
                     $memberNames += ([ADSI]$_).psbase.InvokeGet('Name')
                 }
 
-                If (-Not ($memberNames -Contains $username)) {
+                if (-Not ($memberNames -Contains $username)) {
 
                     # Make sure the user exists, again
                     if ([ADSI]::Exists("WinNT://$computerName/$username")) {
 
                         # Add the user
-                        logmsg "- Adding to $grp"
+                        Write-LogMessage "- Adding to $grp"
                         $group.Add("WinNT://$computerName/$username")
                     }
                 }
@@ -251,34 +262,37 @@ function addLocalUser($context) {
     Write-Host "`r`n" -NoNewline
 }
 
-function configureNetwork($context) {
+function Set-NetworkConfiguration {
+    param (
+        $Context
+    )
 
     # Get the NIC in the Context
-    $nicIds = ($context.Keys | Where-Object { $_ -match '^ETH\d+_MAC$' } | ForEach-Object { $_ -replace '(^ETH|_MAC$)', '' } | Sort-Object -Unique)
+    $nicIds = ($Context.Keys | Where-Object { $_ -match '^ETH\d+_MAC$' } | ForEach-Object { $_ -replace '(^ETH|_MAC$)', '' } | Sort-Object -Unique)
 
     $nicId = 0
 
     foreach ($nicId in $nicIds) {
         $nicPrefix = "ETH" + $nicId + "_"
 
-        $method = $context[$nicPrefix + 'METHOD']
-        $ip = $context[$nicPrefix + 'IP']
-        $netmask = $context[$nicPrefix + 'MASK']
-        $mac = $context[$nicPrefix + 'MAC']
-        $dns = (($context[$nicPrefix + 'DNS'] -split " " | Where-Object { $_ -match '^(([0-9]*).?){4}$' }) -join ' ')
-        $dns6 = (($context[$nicPrefix + 'DNS'] -split " " | Where-Object { $_ -match '^(([0-9A-F]*):?)*$' }) -join ' ')
-        $dnsSuffix = $context[$nicPrefix + 'SEARCH_DOMAIN']
-        $gateway = $context[$nicPrefix + 'GATEWAY']
-        $network = $context[$nicPrefix + 'NETWORK']
-        $mtu = $context[$nicPrefix + 'MTU']
-        $metric = $context[$nicPrefix + 'METRIC']
+        $method = $Context[$nicPrefix + 'METHOD']
+        $ip = $Context[$nicPrefix + 'IP']
+        $netmask = $Context[$nicPrefix + 'MASK']
+        $mac = $Context[$nicPrefix + 'MAC']
+        $dns = (($Context[$nicPrefix + 'DNS'] -split " " | Where-Object { $_ -match '^(([0-9]*).?){4}$' }) -join ' ')
+        $dns6 = (($Context[$nicPrefix + 'DNS'] -split " " | Where-Object { $_ -match '^(([0-9A-F]*):?)*$' }) -join ' ')
+        $dnsSuffix = $Context[$nicPrefix + 'SEARCH_DOMAIN']
+        $gateway = $Context[$nicPrefix + 'GATEWAY']
+        $network = $Context[$nicPrefix + 'NETWORK']
+        $mtu = $Context[$nicPrefix + 'MTU']
+        $metric = $Context[$nicPrefix + 'METRIC']
 
-        $ip6Method = $context[$nicPrefix + 'IP6_METHOD']
-        $ip6 = $context[$nicPrefix + 'IP6']
-        $ip6ULA = $context[$nicPrefix + 'IP6_ULA']
-        $ip6Prefix = $context[$nicPrefix + 'IP6_PREFIX_LENGTH']
-        $ip6Gw = $context[$nicPrefix + 'IP6_GATEWAY']
-        $ip6Metric = $context[$nicPrefix + 'IP6_METRIC']
+        $ip6Method = $Context[$nicPrefix + 'IP6_METHOD']
+        $ip6 = $Context[$nicPrefix + 'IP6']
+        $ip6ULA = $Context[$nicPrefix + 'IP6_ULA']
+        $ip6Prefix = $Context[$nicPrefix + 'IP6_PREFIX_LENGTH']
+        $ip6Gw = $Context[$nicPrefix + 'IP6_GATEWAY']
+        $ip6Metric = $Context[$nicPrefix + 'IP6_METRIC']
 
         $mac = $mac.ToUpper()
         if (!$netmask) {
@@ -290,7 +304,7 @@ function configureNetwork($context) {
         if (!$ip6Gw) {
             # Backward compatibility, new context parameter
             # ETHx_IP6_GATEWAY introduced since 6.2
-            $ip6Gw = $context[$nicPrefix + 'GATEWAY6']
+            $ip6Gw = $Context[$nicPrefix + 'GATEWAY6']
         }
         if (!$ip6Metric) {
             $ip6Metric = $metric
@@ -320,10 +334,10 @@ function configureNetwork($context) {
                 Where-Object { $_.IPEnabled -eq "TRUE" -and $_.MACAddress -eq $mac }
         } while (!$nic -and $retry)
 
-        If (!$nic) {
-            logmsg ("* Configuring Network Settings: " + $mac)
-            logmsg ("  ... Failed: Interface with MAC not found")
-            Continue
+        if (!$nic) {
+            Write-LogMessage ("* Configuring Network Settings: " + $mac)
+            Write-LogMessage ("  ... Failed: Interface with MAC not found")
+            continue
         }
 
         # We need the connection ID (i.e. "Local Area Connection",
@@ -331,102 +345,102 @@ function configureNetwork($context) {
         $na = Get-WMIObject Win32_NetworkAdapter | `
             Where-Object { $_.deviceId -eq $nic.index }
 
-        If (!$na) {
-            logmsg ("* Configuring Network Settings: " + $mac)
-            logmsg ("  ... Failed: Network Adapter not found")
-            Continue
+        if (!$na) {
+            Write-LogMessage ("* Configuring Network Settings: " + $mac)
+            Write-LogMessage ("  ... Failed: Network Adapter not found")
+            continue
         }
 
-        logmsg ("* Configuring Network Settings: " + $nic.Description.ToString())
+        Write-LogMessage ("* Configuring Network Settings: " + $nic.Description.ToString())
 
         # Flag to indicate if any IPv4/6 configuration was placed
-        $set_ip_conf = $false
+        $setIpConf = $false
 
         # IPv4 Configuration Methods
-        Switch -Regex ($method) {
+        switch -Regex ($method) {
             '^\s*static\s*$' {
                 if ($ip) {
                     # Release the DHCP lease, will fail if adapter not DHCP Configured
-                    logmsg "- Release DHCP Lease"
+                    Write-LogMessage "- Release DHCP Lease"
                     $ret = $nic.ReleaseDHCPLease()
-                    If ($ret.ReturnValue) {
-                        logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                    if ($ret.ReturnValue) {
+                        Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                     }
-                    Else {
-                        logmsg "  ... Success"
+                    else {
+                        Write-LogMessage "  ... Success"
                     }
 
                     # set static IP address and retry for few times if there was a problem
                     # with acquiring write lock (2147786788) for network configuration
                     # https://msdn.microsoft.com/en-us/library/aa390383(v=vs.85).aspx
-                    logmsg "- Set Static IP"
+                    Write-LogMessage "- Set Static IP"
                     $retry = 10
                     do {
                         $retry--
                         Start-Sleep -s 1
                         $ret = $nic.EnableStatic($ip , $netmask)
                     } while ($ret.ReturnValue -eq 2147786788 -and $retry)
-                    If ($ret.ReturnValue) {
-                        logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                    if ($ret.ReturnValue) {
+                        Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                     }
-                    Else {
-                        logmsg "  ... Success"
+                    else {
+                        Write-LogMessage "  ... Success"
                     }
 
                     # Set IPv4 MTU
                     if ($mtu) {
-                        logmsg "- Set MTU: ${mtu}"
+                        Write-LogMessage "- Set MTU: ${mtu}"
                         netsh interface ipv4 set interface $nic.InterfaceIndex mtu=$mtu
 
-                        If ($?) {
-                            logmsg "  ... Success"
+                        if ($?) {
+                            Write-LogMessage "  ... Success"
                         }
-                        Else {
-                            logmsg "  ... Failed"
+                        else {
+                            Write-LogMessage "  ... Failed"
                         }
                     }
 
                     # Set the Gateway
                     if ($gateway) {
                         if ($metric) {
-                            logmsg "- Set Gateway with metric"
+                            Write-LogMessage "- Set Gateway with metric"
                             $ret = $nic.SetGateways($gateway, $metric)
                         }
-                        Else {
-                            logmsg "- Set Gateway"
+                        else {
+                            Write-LogMessage "- Set Gateway"
                             $ret = $nic.SetGateways($gateway)
                         }
 
-                        If ($ret.ReturnValue) {
-                            logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                        if ($ret.ReturnValue) {
+                            Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                         }
-                        Else {
-                            logmsg "  ... Success"
+                        else {
+                            Write-LogMessage "  ... Success"
                         }
                     }
 
                     # Set DNS servers
-                    If ($dns) {
+                    if ($dns) {
                         $dnsServers = $dns -split " "
 
                         # DNS Server Search Order
-                        logmsg "- Set DNS Server Search Order"
+                        Write-LogMessage "- Set DNS Server Search Order"
                         $ret = $nic.SetDNSServerSearchOrder($dnsServers)
-                        If ($ret.ReturnValue) {
-                            logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                        if ($ret.ReturnValue) {
+                            Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                         }
-                        Else {
-                            logmsg "  ... Success"
+                        else {
+                            Write-LogMessage "  ... Success"
                         }
 
                         # Set Dynamic DNS Registration
-                        logmsg "- Set Dynamic DNS Registration"
+                        Write-LogMessage "- Set Dynamic DNS Registration"
                         $ret = $nic.SetDynamicDNSRegistration("TRUE")
-                        If ($ret.ReturnValue) {
-                            logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                        if ($ret.ReturnValue) {
+                            Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                         }
-                        Else {
-                            logmsg "  ... Success"
+                        else {
+                            Write-LogMessage "  ... Success"
                         }
 
                         # WINS Addresses
@@ -438,91 +452,91 @@ function configureNetwork($context) {
                         $dnsSuffixes = $dnsSuffix -split " "
 
                         # Set DNS Suffix Search Order
-                        logmsg "- Set DNS Suffix Search Order"
+                        Write-LogMessage "- Set DNS Suffix Search Order"
                         $ret = ([WMIClass]"Win32_NetworkAdapterConfiguration").SetDNSSuffixSearchOrder(($dnsSuffixes))
-                        If ($ret.ReturnValue) {
-                            logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                        if ($ret.ReturnValue) {
+                            Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                         }
-                        Else {
-                            logmsg "  ... Success"
+                        else {
+                            Write-LogMessage "  ... Success"
                         }
 
                         # Set Primary DNS Domain
-                        logmsg "- Set Primary DNS Domain"
+                        Write-LogMessage "- Set Primary DNS Domain"
                         $ret = $nic.SetDNSDomain($dnsSuffixes[0])
-                        If ($ret.ReturnValue) {
-                            logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                        if ($ret.ReturnValue) {
+                            Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                         }
-                        Else {
-                            logmsg "  ... Success"
+                        else {
+                            Write-LogMessage "  ... Success"
                         }
                     }
 
-                    $set_ip_conf = $true
+                    $setIpConf = $true
                 }
                 else {
-                    logmsg "- No static IPv4 configuration provided, skipping"
+                    Write-LogMessage "- No static IPv4 configuration provided, skipping"
                 }
             }
 
             '^\s*dhcp\s*$' {
                 # Enable DHCP
-                logmsg "- Enable DHCP"
+                Write-LogMessage "- Enable DHCP"
                 $ret = $nic.EnableDHCP()
                 # TODO: 1 ... Successful completion, reboot required
-                If ($ret.ReturnValue) {
-                    logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+                if ($ret.ReturnValue) {
+                    Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
                 }
-                Else {
-                    logmsg "  ... Success"
+                else {
+                    Write-LogMessage "  ... Success"
                 }
 
                 # Set IPv4 MTU
                 if ($mtu) {
-                    logmsg "- Set MTU: ${mtu}"
+                    Write-LogMessage "- Set MTU: ${mtu}"
                     netsh interface ipv4 set interface $nic.InterfaceIndex mtu=$mtu
 
-                    If ($?) {
-                        logmsg "  ... Success"
+                    if ($?) {
+                        Write-LogMessage "  ... Success"
                     }
-                    Else {
-                        logmsg "  ... Failed"
+                    else {
+                        Write-LogMessage "  ... Failed"
                     }
                 }
 
-                $set_ip_conf = $true
+                $setIpConf = $true
             }
 
             '\s*skip\s*$' {
-                logmsg "- Skipped IPv4 configuration as requested in method (${nicPrefix}METHOD=${method})"
+                Write-LogMessage "- Skipped IPv4 configuration as requested in method (${nicPrefix}METHOD=${method})"
             }
 
-            Default {
-                logmsg "- Unknown IPv4 method (${nicPrefix}METHOD=${method}), skipping configuration"
+            default {
+                Write-LogMessage "- Unknown IPv4 method (${nicPrefix}METHOD=${method}), skipping configuration"
             }
         }
 
         # IPv6 Configuration Methods
-        Switch -Regex ($ip6Method) {
+        switch -Regex ($ip6Method) {
             '^\s*static\s*$' {
                 if ($ip6) {
-                    enableIPv6
-                    disableIPv6Privacy
+                    Enable-NetworkIPv6
+                    Disable-NetworkIPv6Privacy
 
                     # Disable router discovery
-                    logmsg "- Disable IPv6 router discovery"
+                    Write-LogMessage "- Disable IPv6 router discovery"
                     netsh interface ipv6 set interface $na.NetConnectionId `
                         advertise=disabled routerdiscover=disabled | Out-Null
 
-                    If ($?) {
-                        logmsg "  ... Success"
+                    if ($?) {
+                        Write-LogMessage "  ... Success"
                     }
-                    Else {
-                        logmsg "  ... Failed"
+                    else {
+                        Write-LogMessage "  ... Failed"
                     }
 
                     # Remove old IPv6 addresses
-                    logmsg "- Removing old IPv6 addresses"
+                    Write-LogMessage "- Removing old IPv6 addresses"
                     if (Get-Command Remove-NetIPAddress -ErrorAction SilentlyContinue) {
                         # Windows 8.1 and Server 2012 R2 and up
                         # we want to remove everything except the link-local address
@@ -531,91 +545,91 @@ function configureNetwork($context) {
                             -PrefixOrigin Other, Manual, Dhcp, RouterAdvertisement `
                             -errorAction SilentlyContinue
 
-                        If ($?) {
-                            logmsg "  ... Success"
+                        if ($?) {
+                            Write-LogMessage "  ... Success"
                         }
-                        Else {
-                            logmsg "  ... Nothing to do"
+                        else {
+                            Write-LogMessage "  ... Nothing to do"
                         }
                     }
-                    Else {
-                        logmsg "  ... Not implemented"
+                    else {
+                        Write-LogMessage "  ... Not implemented"
                     }
 
                     # Set IPv6 Address
-                    logmsg "- Set IPv6 Address"
+                    Write-LogMessage "- Set IPv6 Address"
                     netsh interface ipv6 add address $na.NetConnectionId $ip6/$ip6Prefix
-                    If ($? -And $ip6ULA) {
+                    if ($? -And $ip6ULA) {
                         netsh interface ipv6 add address $na.NetConnectionId $ip6ULA/64
                     }
 
-                    If ($?) {
-                        logmsg "  ... Success"
+                    if ($?) {
+                        Write-LogMessage "  ... Success"
                     }
-                    Else {
-                        logmsg "  ... Failed"
+                    else {
+                        Write-LogMessage "  ... Failed"
                     }
 
                     # Set IPv6 Gateway
                     if ($ip6Gw) {
                         if ($ip6Metric) {
-                            logmsg "- Set IPv6 Gateway with metric"
+                            Write-LogMessage "- Set IPv6 Gateway with metric"
                             netsh interface ipv6 add route ::/0 $na.NetConnectionId $ip6Gw metric="${ip6Metric}"
                         }
                         else {
-                            logmsg "- Set IPv6 Gateway"
+                            Write-LogMessage "- Set IPv6 Gateway"
                             netsh interface ipv6 add route ::/0 $na.NetConnectionId $ip6Gw
                         }
 
-                        If ($?) {
-                            logmsg "  ... Success"
+                        if ($?) {
+                            Write-LogMessage "  ... Success"
                         }
-                        Else {
-                            logmsg "  ... Failed"
+                        else {
+                            Write-LogMessage "  ... Failed"
                         }
                     }
 
                     # Set IPv6 MTU
                     if ($mtu) {
-                        logmsg "- Set IPv6 MTU: ${mtu}"
+                        Write-LogMessage "- Set IPv6 MTU: ${mtu}"
                         netsh interface ipv6 set interface $nic.InterfaceIndex mtu=$mtu
 
-                        If ($?) {
-                            logmsg "  ... Success"
+                        if ($?) {
+                            Write-LogMessage "  ... Success"
                         }
-                        Else {
-                            logmsg "  ... Failed"
+                        else {
+                            Write-LogMessage "  ... Failed"
                         }
                     }
 
                     # Remove old IPv6 DNS Servers
-                    logmsg "- Removing old IPv6 DNS Servers"
+                    Write-LogMessage "- Removing old IPv6 DNS Servers"
                     netsh interface ipv6 set dnsservers $na.NetConnectionId source=static address=
 
-                    If ($dns6) {
+                    if ($dns6) {
                         # Set IPv6 DNS Servers
-                        logmsg "- Set IPv6 DNS Servers"
+                        Write-LogMessage "- Set IPv6 DNS Servers"
                         $dns6Servers = $dns6 -split " "
                         foreach ($dns6Server in $dns6Servers) {
                             netsh interface ipv6 add dnsserver $na.NetConnectionId address=$dns6Server
                         }
                     }
 
-                    $set_ip_conf = $true
+                    $setIpConf = $true
 
-                    doPing($ip6)
+                    Test-ConnectionPing($ip6)
                 }
                 else {
-                    logmsg "- No static IPv6 configuration provided, skipping"
+                    Write-LogMessage "- No static IPv6 configuration provided, skipping"
                 }
             }
 
             '^\s*(auto|dhcp)\s*$' {
-                enableIPv6
-                disableIPv6Privacy
+                Enable-NetworkIPv6
+                Disable-NetworkIPv6Privacy
 
                 # Enable router discovery
-                logmsg "- Enable IPv6 router discovery"
+                Write-LogMessage "- Enable IPv6 router discovery"
                 netsh interface ipv6 set interface $na.NetConnectionId `
                     advertise=disabled routerdiscover=enabled | Out-Null
 
@@ -625,68 +639,68 @@ function configureNetwork($context) {
                 # through DHCPv6 in auto mode. See
                 # https://serverfault.com/questions/692291/disable-dhcpv6-client-in-windows
                 if ($ip6Method -match '^\s*auto\s*$') {
-                    logmsg "- Release DHCPv6 Lease (selected method auto, not dhcp!)"
+                    Write-LogMessage "- Release DHCPv6 Lease (selected method auto, not dhcp!)"
                     ipconfig /release6 $na.NetConnectionId
 
-                    If ($?) {
-                        logmsg "  ... Success"
+                    if ($?) {
+                        Write-LogMessage "  ... Success"
                     }
-                    Else {
-                        logmsg "  ... Failed"
+                    else {
+                        Write-LogMessage "  ... Failed"
                     }
                 }
 
                 # Set IPv6 MTU
                 if ($mtu) {
-                    logmsg "- Set IPv6 MTU: ${mtu}"
-                    logmsg "WARNING: MTU will be overwritten if announced as part of RA!"
+                    Write-LogMessage "- Set IPv6 MTU: ${mtu}"
+                    Write-LogMessage "WARNING: MTU will be overwritten if announced as part of RA!"
                     netsh interface ipv6 set interface $nic.InterfaceIndex mtu=$mtu
 
-                    If ($?) {
-                        logmsg "  ... Success"
+                    if ($?) {
+                        Write-LogMessage "  ... Success"
                     }
-                    Else {
-                        logmsg "  ... Failed"
+                    else {
+                        Write-LogMessage "  ... Failed"
                     }
                 }
 
-                $set_ip_conf = $true
+                $setIpConf = $true
             }
 
             '^\s*disable\s*$' {
-                disableIPv6
+                Disable-NetworkIPv6
             }
 
             '\s*skip\s*$' {
-                logmsg "- Skipped IPv6 configuration as requested in method (${nicPrefix}IP6_METHOD=${ip6Method})"
+                Write-LogMessage "- Skipped IPv6 configuration as requested in method (${nicPrefix}IP6_METHOD=${ip6Method})"
             }
 
-            Default {
-                logmsg "- Unknown IPv6 method (${nicPrefix}IP6_METHOD=${ip6Method}), skipping configuration"
+            default {
+                Write-LogMessage "- Unknown IPv6 method (${nicPrefix}IP6_METHOD=${ip6Method}), skipping configuration"
             }
         }
 
         ###
 
-        # If no IP configuration happened, we skip
+        # if no IP configuration happened, we skip
         # configuring additional IP addresses (aliases)
-        If ($set_ip_conf -eq $false) {
-            logmsg "- Skipped IP aliases configuration due to missing main IP"
-            Continue
+        if ($setIpConf -eq $false) {
+            Write-LogMessage "- Skipped IP aliases configuration due to missing main IP"
+            continue
         }
 
         # Get the aliases for the NIC in the Context
-        $aliasIds = ($context.Keys | Where-Object { $_ -match "^ETH${nicId}_ALIAS\d+_IP6?$" } | ForEach-Object { $_ -replace '(^ETH\d+_ALIAS|_IP$|_IP6$)', '' } | Sort-Object -Unique)
+        $aliasIds = ($Context.Keys | Where-Object { $_ -match "^ETH${nicId}_ALIAS\d+_IP6?$" } | ForEach-Object { $_ -replace '(^ETH\d+_ALIAS|_IP$|_IP6$)', '' } | Sort-Object -Unique)
 
         foreach ($aliasId in $aliasIds) {
             $aliasPrefix = "ETH${nicId}_ALIAS${aliasId}"
-            $aliasIp = $context[$aliasPrefix + '_IP']
-            $aliasNetmask = $context[$aliasPrefix + '_MASK']
-            $aliasIp6 = $context[$aliasPrefix + '_IP6']
-            $aliasIp6ULA = $context[$aliasPrefix + '_IP6_ULA']
-            $aliasIp6Prefix = $context[$aliasPrefix + '_IP6_PREFIX_LENGTH']
-            $detach = $context[$aliasPrefix + '_DETACH']
-            $external = $context[$aliasPrefix + '_EXTERNAL']
+            $aliasIp = $Context[$aliasPrefix + '_IP']
+            $aliasNetmask = $Context[$aliasPrefix + '_MASK']
+            $aliasIp6 = $Context[$aliasPrefix + '_IP6']
+            $aliasIp6ULA = $Context[$aliasPrefix + '_IP6_ULA']
+            $aliasIp6Prefix = $Context[$aliasPrefix + '_IP6_PREFIX_LENGTH']
+            $detach = $Context[$aliasPrefix + '_DETACH']
+            $external = $Context[$aliasPrefix + '_EXTERNAL']
 
             if ($external -and ($external -eq "YES")) {
                 continue
@@ -701,111 +715,117 @@ function configureNetwork($context) {
             }
 
             if ($aliasIp -and !$detach) {
-                logmsg "- Set Additional Static IP (${aliasPrefix})"
+                Write-LogMessage "- Set Additional Static IP (${aliasPrefix})"
                 netsh interface ipv4 add address $nic.InterfaceIndex $aliasIp $aliasNetmask
 
-                If ($?) {
-                    logmsg "  ... Success"
+                if ($?) {
+                    Write-LogMessage "  ... Success"
                 }
-                Else {
-                    logmsg "  ... Failed"
+                else {
+                    Write-LogMessage "  ... Failed"
                 }
             }
 
             if ($aliasIp6 -and !$detach) {
-                logmsg "- Set Additional IPv6 Address (${aliasPrefix})"
+                Write-LogMessage "- Set Additional IPv6 Address (${aliasPrefix})"
                 netsh interface ipv6 add address $nic.InterfaceIndex $aliasIp6/$aliasIp6Prefix
-                If ($? -And $aliasIp6ULA) {
+                if ($? -And $aliasIp6ULA) {
                     netsh interface ipv6 add address $nic.InterfaceIndex $aliasIp6ULA/64
                 }
 
-                If ($?) {
-                    logmsg "  ... Success"
+                if ($?) {
+                    Write-LogMessage "  ... Success"
                 }
-                Else {
-                    logmsg "  ... Failed"
+                else {
+                    Write-LogMessage "  ... Failed"
                 }
             }
         }
 
-        If ($ip) {
-            doPing($ip)
+        if ($ip) {
+            Test-ConnectionPing($ip)
         }
     }
 
     Write-Host "`r`n" -NoNewline
 }
 
-function setTimeZone($context) {
-    $timezone = $context['TIMEZONE']
+function Set-TimeZone {
+    param (
+        $Context
+    )
+    $timezone = $Context['TIMEZONE']
 
-    If ($timezone) {
-        logmsg "* Configuring time zone '${timezone}'"
+    if ($timezone) {
+        Write-LogMessage "* Configuring time zone '${timezone}'"
 
         tzutil /s "${timezone}"
 
-        If ($?) {
-            logmsg '  ... Success'
+        if ($?) {
+            Write-LogMessage '  ... Success'
         }
-        Else {
-            logmsg '  ... Failed'
+        else {
+            Write-LogMessage '  ... Failed'
         }
     }
 }
 
-function renameComputer($context) {
+function Rename-Computer {
+    param (
+        $Context
+    )
     # Initialize Variables
-    $current_hostname = hostname
-    $context_hostname = $context["SET_HOSTNAME"]
+    $currentHostname = hostname
+    $contextHostname = $Context["SET_HOSTNAME"]
 
     # SET_HOSTNAME was not set but maybe DNS_HOSTNAME was...
-    if (! $context_hostname) {
-        $dns_hostname = $context["DNS_HOSTNAME"]
+    if (! $contextHostname) {
+        $dnsHostname = $Context["DNS_HOSTNAME"]
 
-        if ($null -ne $dns_hostname -and $dns_hostname.ToUpper() -eq "YES") {
+        if ($null -ne $dnsHostname -and $dnsHostname.ToUpper() -eq "YES") {
 
             # we will set our hostname based on the reverse dns lookup - the IP
             # in question is the first one with a set default gateway
             # (as is done by get_first_ip in addon-context-linux)
 
-            logmsg "* Requested change of Hostname via reverse DNS lookup (DNS_HOSTNAME=YES)"
+            Write-LogMessage "* Requested change of Hostname via reverse DNS lookup (DNS_HOSTNAME=YES)"
             $first_ip = (Get-WmiObject -Class Win32_NetworkAdapterConfiguration | Where-Object { $null -ne $_.DefaultIPGateway }).IPAddress | Select-Object -First 1
-            $context_hostname = [System.Net.Dns]::GetHostbyAddress($first_ip).HostName
-            logmsg "- Resolved Hostname is: $context_hostname"
+            $contextHostname = [System.Net.Dns]::GetHostbyAddress($first_ip).HostName
+            Write-LogMessage "- Resolved Hostname is: $contextHostname"
         }
-        Else {
+        else {
 
             # no SET_HOSTNAME nor DNS_HOSTNAME - skip setting hostname
             return
         }
     }
 
-    $splitted_hostname = $context_hostname.split('.')
-    $context_hostname = $splitted_hostname[0]
-    $context_domain = $splitted_hostname[1..$splitted_hostname.length] -join '.'
+    $splittedHostname = $contextHostname.split('.')
+    $contextHostname = $splittedHostname[0]
+    $contextDomain = $splittedHostname[1..$splittedHostname.length] -join '.'
 
-    If ($context_domain) {
-        logmsg "* Changing Domain to $context_domain"
+    if ($contextDomain) {
+        Write-LogMessage "* Changing Domain to $contextDomain"
 
         $networkConfig = Get-WmiObject Win32_NetworkAdapterConfiguration -filter "ipenabled = 'true'"
-        $ret = $networkConfig.SetDnsDomain($context_domain)
+        $ret = $networkConfig.SetDnsDomain($contextDomain)
 
-        If ($ret.ReturnValue) {
+        if ($ret.ReturnValue) {
 
             # Returned Non Zero, Failed, No restart
-            logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+            Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
         }
-        Else {
+        else {
 
             # Returned Zero, Success
-            logmsg "  ... Success"
+            Write-LogMessage "  ... Success"
         }
     }
 
     # Check for the .opennebula-renamed file
-    $logged_hostname = ""
-    If (Test-Path "$ctxDir\.opennebula-renamed") {
-        logmsg "- Using the JSON file: $ctxDir\.opennebula-renamed"
+    $loggedHostname = ""
+    if (Test-Path "$ctxDir\.opennebula-renamed") {
+        Write-LogMessage "- Using the JSON file: $ctxDir\.opennebula-renamed"
 
         # Grab the JSON content
         $json = Get-Content -Path "$ctxDir\.opennebula-renamed" `
@@ -814,260 +834,269 @@ function renameComputer($context) {
         # Convert to a Hash Table and set the Logged Hostname
         try {
             $status = $json | ConvertFrom-Json
-            $logged_hostname = $status.ComputerName
+            $loggedHostname = $status.ComputerName
         }
         # Invalid JSON
         catch [System.ArgumentException] {
-            logmsg " [!] Invalid JSON:"
+            Write-LogMessage " [!] Invalid JSON:"
             Write-Host $json.ToString()
         }
     }
-    Else {
+    else {
 
         # no renaming was ever done - we fallback to our current Hostname
-        $logged_hostname = $current_hostname
+        $loggedHostname = $currentHostname
     }
 
-    If (($current_hostname -ne $context_hostname) -and `
-        ($context_hostname -eq $logged_hostname)) {
+    if (($currentHostname -ne $contextHostname) -and `
+        ($contextHostname -eq $loggedHostname)) {
 
         # avoid rename->reboot loop - if we detect that rename attempt was done
         # but failed then we drop log message about it and finish...
 
-        logmsg "* Computer Rename Attempted but failed:"
-        logmsg "- Current: $current_hostname"
-        logmsg "- Context: $context_hostname"
+        Write-LogMessage "* Computer Rename Attempted but failed:"
+        Write-LogMessage "- Current: $currentHostname"
+        Write-LogMessage "- Context: $contextHostname"
     }
-    ElseIf ($context_hostname -ne $current_hostname) {
+    ElseIf ($contextHostname -ne $currentHostname) {
 
         # the current_name does not match the context_name, rename the computer
 
-        logmsg "* Changing Hostname to $context_hostname"
+        Write-LogMessage "* Changing Hostname to $contextHostname"
         # Load the ComputerSystem Object
         $ComputerInfo = Get-WmiObject -Class Win32_ComputerSystem
 
         # Rename the computer
-        $ret = $ComputerInfo.rename($context_hostname)
+        $ret = $ComputerInfo.rename($contextHostname)
 
         $contents = @{}
-        $contents["ComputerName"] = $context_hostname
+        $contents["ComputerName"] = $contextHostname
         ConvertTo-Json $contents | Out-File "$ctxDir\.opennebula-renamed"
 
         # Check success
-        If ($ret.ReturnValue) {
+        if ($ret.ReturnValue) {
 
             # Returned Non Zero, Failed, No restart
-            logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+            Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
             Write-Host "      Check the computername. "
             Write-Host "Possible Issues: The name cannot include control " `
                 "characters, leading or trailing spaces, or any of " `
                 "the following characters: `" / \ [ ] : | < > + = ; , ?"
 
         }
-        Else {
+        else {
 
             # Returned Zero, Success
-            logmsg "  ... Success"
+            Write-LogMessage "  ... Success"
 
             # Restart the Computer
-            logmsg "  ... Rebooting"
+            Write-LogMessage "  ... Rebooting"
             Restart-Computer -Force
 
             # Exit here so the script doesn't continue to run
             Exit 0
         }
     }
-    Else {
+    else {
 
         # Hostname is set and correct
-        logmsg "* Computer Name already set: $context_hostname"
+        Write-LogMessage "* Computer Name already set: $contextHostname"
     }
 
     Write-Host "`r`n" -NoNewline
 }
 
-function enableRemoteDesktop() {
-    logmsg "* Enabling Remote Desktop"
+function Enable-RemoteDesktop {
+    Write-LogMessage "* Enabling Remote Desktop"
     # Windows 7 only - add firewall exception for RDP
-    logmsg "- Enable Remote Desktop Rule Group"
+    Write-LogMessage "- Enable Remote Desktop Rule Group"
     netsh advfirewall Firewall set rule group="Remote Desktop" new enable=yes
 
     # Enable RDP
-    logmsg "- Enable Allow Terminal Services Connections"
+    Write-LogMessage "- Enable Allow Terminal Services Connections"
     $ret = (Get-WmiObject -Class "Win32_TerminalServiceSetting" -Namespace root\cimv2\terminalservices).SetAllowTsConnections(1)
-    If ($ret.ReturnValue) {
-        logmsg ("  ... Failed: " + $ret.ReturnValue.ToString())
+    if ($ret.ReturnValue) {
+        Write-LogMessage ("  ... Failed: " + $ret.ReturnValue.ToString())
     }
-    Else {
-        logmsg "  ... Success"
+    else {
+        Write-LogMessage "  ... Success"
     }
     Write-Host "`r`n" -NoNewline
 }
 
-function enableSSH() {
-    logmsg "* Enabling SSH"
+function Enable-SSH {
+    Write-LogMessage "* Enabling SSH"
     # Get sshd service
     $serviceName = "sshd"
     $sshdService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
-    
+
     # Check if service is present
     if ($sshdService) {
         # Service is running and automatic start is enabled
         if ($sshdService.StartType -eq "Automatic" -and $sshdService.Status -eq "Running") {
-            logmsg " ... Success (Service is already enabled and running )"
+            Write-LogMessage " ... Success (Service is already enabled and running )"
             return
         }
         # Enable autostart
         if ($sshdService.StartType -ne "Automatic") {
-            logmsg "- Enabling automatic start for SSH service"
+            Write-LogMessage "- Enabling automatic start for SSH service"
             Set-Service -Name $serviceName -StartupType Automatic
             if ($?) {
-                logsuccess
+                Write-LogMessage "  ... Success"
             } else {
-                logfail
+                Write-LogMessage "  ... Failed"
                 return
             }
         }
         # Start service
         if ($sshdService.Status -ne "Running") {
-            logmsg "- Starting SSH service"
-        Start-Service -Name $serviceName
-        if ($?) {
-            logsuccess
-        } else {
-            logfail
+            Write-LogMessage "- Starting SSH service"
+            Start-Service -Name $serviceName
+            if ($?) {
+                Write-LogMessage "  ... Success"
+            } else {
+                Write-LogMessage "  ... Failed"
+            }
         }
-    }
     } else {
         # OpenSSH.Server feature is not installed
-        logmsg " ... Failed (OpenSSH Server is not installed)"
+        Write-LogMessage " ... Failed (OpenSSH Server is not installed)"
     }
 }
 
-function enablePing() {
-    logmsg "* Enabling Ping"
+function Enable-Ping {
+    Write-LogMessage "* Enabling Ping"
     #Create firewall manager object
     New-Object -com hnetcfg.fwmgr
 
     # Get current profile
     $pro = $fwmgcalPolicy.CurrentProfile
 
-    logmsg "- Enable Allow Inbound Echo Requests"
+    Write-LogMessage "- Enable Allow Inbound Echo Requests"
     $ret = $pro.IcmpSettings.AllowInboundEchoRequest = $true
-    If ($ret) {
-        logmsg "  ... Success"
+    if ($ret) {
+        Write-LogMessage "  ... Success"
     }
-    Else {
-        logmsg "  ... Failed"
+    else {
+        Write-LogMessage "  ... Failed"
     }
 
     Write-Host "`r`n" -NoNewline
 }
 
-function doPing($ip, $retries = 20) {
-    logmsg "- Ping Interface IP $ip"
+function Test-ConnectionPing {
+    param (
+        $IP,
+        $Retries = 20
+    )
+
+    Write-LogMessage "- Ping Interface IP $IP"
 
     $ping = $false
     $retry = 0
     do {
         $retry++
         Start-Sleep -s 1
-        $ping = Test-Connection -ComputerName $ip -Count 1 -Quiet -ErrorAction SilentlyContinue
-    } while (!$ping -and ($retry -lt $retries))
+        $ping = Test-Connection -ComputerName $IP -Count 1 -Quiet -ErrorAction SilentlyContinue
+    } while (!$ping -and ($retry -lt $Retries))
 
-    If ($ping) {
-        logmsg "  ... Success ($retry tries)"
+    if ($ping) {
+        Write-LogMessage "  ... Success ($retry tries)"
     }
-    Else {
-        logmsg "  ... Failed ($retry tries)"
+    else {
+        Write-LogMessage "  ... Failed ($retry tries)"
     }
 }
 
-function disableIPv6Privacy() {
+function Disable-NetworkIPv6Privacy {
     # Disable Randomization of IPv6 addresses (use EUI-64)
-    logmsg "- Globally disable IPv6 Identifiers Randomization"
+    Write-LogMessage "- Globally disable IPv6 Identifiers Randomization"
     netsh interface ipv6 set global randomizeidentifiers=disable
 
-    If ($?) {
-        logmsg "  ... Success"
+    if ($?) {
+        Write-LogMessage "  ... Success"
     }
-    Else {
-        logmsg "  ... Failed"
+    else {
+        Write-LogMessage "  ... Failed"
     }
 
     # Disable IPv6 Privacy Extensions (temporary addresses)
-    logmsg "- Globally disable IPv6 Privacy Extensions"
+    Write-LogMessage "- Globally disable IPv6 Privacy Extensions"
     netsh interface ipv6 set privacy state=disabled
 
-    If ($?) {
-        logmsg "  ... Success"
+    if ($?) {
+        Write-LogMessage "  ... Success"
     }
-    Else {
-        logmsg "  ... Failed"
+    else {
+        Write-LogMessage "  ... Failed"
     }
 }
 
-function enableIPv6() {
-    logmsg '- Enabling IPv6'
+function Enable-NetworkIPv6 {
+    Write-LogMessage '- Enabling IPv6'
 
     Enable-NetAdapterBinding -Name $na.NetConnectionId -ComponentID ms_tcpip6
 
-    If ($?) {
-        logmsg "  ... Success"
+    if ($?) {
+        Write-LogMessage "  ... Success"
     }
-    Else {
-        logmsg "  ... Failed"
+    else {
+        Write-LogMessage "  ... Failed"
     }
 }
 
-function disableIPv6() {
-    logmsg '- Disabling IPv6'
+function Disable-NetworkIPv6 {
+    Write-LogMessage '- Disabling IPv6'
 
     Disable-NetAdapterBinding -Name $na.NetConnectionId -ComponentID ms_tcpip6
 
-    If ($?) {
-        logmsg "  ... Success"
+    if ($?) {
+        Write-LogMessage "  ... Success"
     }
-    Else {
-        logmsg "  ... Failed"
+    else {
+        Write-LogMessage "  ... Failed"
     }
 }
 
-function runScripts($context, $contextPaths) {
-    logmsg "* Running Scripts"
+function Invoke-ScriptSetExecution {
+    param (
+        $Context,
+        $ContextPaths
+    )
+    Write-LogMessage "* Running Scripts"
 
     # Get list of scripts to run, " " delimited
-    $initscripts = $context["INIT_SCRIPTS"]
+    $initscripts = $Context["INIT_SCRIPTS"]
 
     if ($initscripts) {
         # Parse each script and run it
-        ForEach ($script in $initscripts.split(" ")) {
+        foreach ($script in $initscripts.split(" ")) {
 
             # Sanitize the filename (drop any path from them and instead use our directory)
-            $script = $contextPaths.contextInitScriptPath + [System.IO.Path]::GetFileName($script.Trim())
+            $script = $ContextPaths.contextInitScriptPath + [System.IO.Path]::GetFileName($script.Trim())
 
             if (Test-Path $script) {
-                logmsg "- $script"
-                envContext($context)
-                pswrapper "$script"
+                Write-LogMessage "- $script"
+                Set-EnvironmentContext($Context)
+                Invoke-PowerShellWrapper "$script"
             }
 
         }
     }
     else {
         # Emulate the init.sh fallback behavior from Linux
-        $script = $contextPaths.contextInitScriptPath + "init.ps1"
+        $script = $ContextPaths.contextInitScriptPath + "init.ps1"
 
         if (Test-Path $script) {
-            logmsg "- $script"
-            envContext($context)
-            pswrapper "$script"
+            Write-LogMessage "- $script"
+            Set-EnvironmentContext($Context)
+            Invoke-PowerShellWrapper "$script"
         }
     }
 
     # Execute START_SCRIPT or START_SCRIPT_64
-    $startScript = $context["START_SCRIPT"]
-    $startScript64 = $context["START_SCRIPT_BASE64"]
+    $startScript = $Context["START_SCRIPT"]
+    $startScript64 = $Context["START_SCRIPT_BASE64"]
 
     if ($startScript64) {
         $startScript = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($startScript64))
@@ -1080,20 +1109,27 @@ function runScripts($context, $contextPaths) {
         $startScript | Out-File $startScriptPS "UTF8"
 
         # Launch the Script
-        logmsg "- $startScriptPS"
-        envContext($context)
-        pswrapper "$startScriptPS"
-        removeFile "$startScriptPS"
+        Write-LogMessage "- $startScriptPS"
+        Set-EnvironmentContext($Context)
+        Invoke-PowerShellWrapper "$startScriptPS"
+        Remove-File "$startScriptPS"
     }
     Write-Host "`r`n" -NoNewline
 }
 
-function extendPartition($disk, $part) {
-    "select disk $disk", "select partition $part", "extend" | diskpart | Out-Null
+function Resize-Partition {
+    param (
+        $Disk,
+        $Part
+    )
+    "select disk $Disk", "select partition $Part", "extend" | diskpart | Out-Null
 }
 
-function extendPartitions($context) {
-    logmsg "* Extend partitions"
+function Resize-PartitionSet {
+    param (
+        $Context
+    )
+    Write-LogMessage "* Extend partitions"
 
     "rescan" | diskpart
 
@@ -1101,17 +1137,17 @@ function extendPartitions($context) {
 
     # Cmdlet 'Get-Partition' is not in older Windows/Powershell versions
     if (Get-Command -ErrorAction SilentlyContinue -Name Get-Partition) {
-        if ([string]$context['GROW_ROOTFS'] -eq '' -or $context['GROW_ROOTFS'].ToUpper() -eq 'YES') {
+        if ([string]$Context['GROW_ROOTFS'] -eq '' -or $Context['GROW_ROOTFS'].ToUpper() -eq 'YES') {
             # Add at least system drive
-            $drives = "$env:systemdrive $($context['GROW_FS'])"
+            $drives = "$env:systemdrive $($Context['GROW_FS'])"
         }
         else {
-            $drives = "$($context['GROW_FS'])"
+            $drives = "$($Context['GROW_FS'])"
         }
 
         $driveLetters = (-split $drives | Select-String -Pattern "^(\w):?[\/]?$" -AllMatches | ForEach-Object { $_.matches.groups[1].Value } | Sort-Object -Unique)
 
-        ForEach ($driveLetter in $driveLetters) {
+        foreach ($driveLetter in $driveLetters) {
             $disk = New-Object PsObject -Property @{
                 name    = $null
                 diskId  = $null
@@ -1125,7 +1161,7 @@ function extendPartitions($context) {
             $disks += $disk
         }
     }
-    Else {
+    else {
         # always resize at least the disk 0
         $disk = New-Object PsObject -Property @{
             name    = $null
@@ -1139,48 +1175,52 @@ function extendPartitions($context) {
     }
 
     # extend all requested disk/part
-    ForEach ($disk in $disks) {
-        ForEach ($partId in $disk.partIds) {
+    foreach ($disk in $disks) {
+        foreach ($partId in $disk.partIds) {
             if ($disk.name) {
-                logmsg "- Extend ($($disk.name)) Disk: $($disk.diskId) / Part: $partId"
+                Write-LogMessage "- Extend ($($disk.name)) Disk: $($disk.diskId) / Part: $partId"
             }
-            Else {
-                logmsg "- Extend Disk: $($disk.diskId) / Part: $partId"
+            else {
+                Write-LogMessage "- Extend Disk: $($disk.diskId) / Part: $partId"
             }
-            extendPartition $disk.diskId $partId
+            Resize-Partition $disk.diskId $partId
         }
     }
 }
 
-function reportReady($context, $contextLetter) {
-    $reportReady = $context['REPORT_READY']
-    $oneGateEndpoint = $context['ONEGATE_ENDPOINT']
-    $vmId = $context['VMID']
-    $token = $context['ONEGATE_TOKEN']
+function Invoke-ReportReady {
+    param (
+        $Context,
+        $ContextLetter
+    )
+    $reportReady = $Context['REPORT_READY']
+    $oneGateEndpoint = $Context['ONEGATE_ENDPOINT']
+    $vmId = $Context['VMID']
+    $token = $Context['ONEGATE_TOKEN']
     $retryCount = 3
     $retryWaitPeriod = 10
 
     if ($reportReady -and $reportReady.ToUpper() -eq 'YES') {
-        logmsg '* Report Ready to OneGate'
+        Write-LogMessage '* Report Ready to OneGate'
 
         if (!$oneGateEndpoint) {
-            logmsg '  ... Failed: ONEGATE_ENDPOINT not set'
+            Write-LogMessage '  ... Failed: ONEGATE_ENDPOINT not set'
             return
         }
 
         if (!$vmId) {
-            logmsg '  ... Failed: VMID not set'
+            Write-LogMessage '  ... Failed: VMID not set'
             return
         }
 
         if (!$token) {
-            logmsg "  ... Token not set. Try file"
-            $tokenPath = $contextLetter + 'token.txt'
+            Write-LogMessage "  ... Token not set. Try file"
+            $tokenPath = $ContextLetter + 'token.txt'
             if (Test-Path $tokenPath) {
                 $token = Get-Content $tokenPath
             }
             else {
-                logmsg "  ... Failed: Token file not found"
+                Write-LogMessage "  ... Failed: Token file not found"
                 return
             }
         }
@@ -1201,7 +1241,7 @@ function reportReady($context, $contextLetter) {
 
                 if ($oneGateEndpoint -ilike "https://*") {
                     #For reporting on HTTPS OneGateEndpoint
-                    logmsg "  ... Use HTTPS for OneGateEndpoint report: $oneGateEndpoint"
+                    Write-LogMessage "  ... Use HTTPS for OneGateEndpoint report: $oneGateEndpoint"
                     $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
                     [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
                     [System.Net.ServicePointManager]::Expect100Continue = $false
@@ -1215,106 +1255,121 @@ function reportReady($context, $contextLetter) {
 
                 $response = $webRequest.getResponse()
                 if ($response.StatusCode -eq 'OK') {
-                    logmsg '  ... Success'
+                    Write-LogMessage '  ... Success'
                     break
                 }
                 else {
-                    logmsg "  ... Failed: $($response.StatusCode)"
+                    Write-LogMessage "  ... Failed: $($response.StatusCode)"
                 }
             }
             catch {
                 $errorMessage = $_.Exception.Message
-                logmsg "  ... Failed: $errorMessage"
+                Write-LogMessage "  ... Failed: $errorMessage"
             }
 
-            logmsg "  ... Report ready failed (${retryNumber}. try out of ${retryCount})"
+            Write-LogMessage "  ... Report ready failed (${retryNumber}. try out of ${retryCount})"
             $retryNumber++
             if ($retryNumber -le $retryCount) {
-                logmsg "  ... sleep for ${retryWaitPeriod} seconds and try again..."
+                Write-LogMessage "  ... sleep for ${retryWaitPeriod} seconds and try again..."
                 Start-Sleep -Seconds $retryWaitPeriod
             }
             else {
-                logmsg "  ... All retries failed!"
+                Write-LogMessage "  ... All retries failed!"
                 break
             }
         }
     }
 }
 
-function ejectContextCD($cdrom_drive) {
-    if (-Not $cdrom_drive) {
+function Dismount-ContextCD {
+    param (
+        $CdromDrive
+    )
+    if (-Not $CdromDrive) {
         return
     }
 
     $eject_cdrom = $context['EJECT_CDROM']
 
     if ($null -ne $eject_cdrom -and $eject_cdrom.ToUpper() -eq 'YES') {
-        logmsg '* Ejecting context CD'
+        Write-LogMessage '* Ejecting context CD'
         try {
             #https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
             $ssfDRIVES = 0x11
             $sh = New-Object -ComObject "Shell.Application"
-            $sh.Namespace($ssfDRIVES).Items() | Where-Object { $_.Type -eq "CD Drive" -and $_.Path -eq $cdrom_drive.Name } | ForEach-Object {
+            $sh.Namespace($ssfDRIVES).Items() | Where-Object { $_.Type -eq "CD Drive" -and $_.Path -eq $CdromDrive.Name } | ForEach-Object {
                 $_.InvokeVerb("Eject")
-                logmsg " ... Ejected $($cdrom_drive.Name)"
+                Write-LogMessage " ... Ejected $($CdromDrive.Name)"
             }
         }
         catch {
-            logmsg "  ... Failed to eject the CD: $_"
+            Write-LogMessage "  ... Failed to eject the CD: $_"
         }
     }
 }
 
-function removeFile($file) {
-    if (![string]::IsNullOrEmpty($file) -and (Test-Path $file)) {
-        logmsg "* Removing the file: ${file}"
-        Remove-Item -Path $file -Force
+function Remove-File($file) {
+    param (
+        $File
+    )
+    if (![string]::IsNullOrEmpty($File) -and (Test-Path $File)) {
+        Write-LogMessage "* Removing the file: ${File}"
+        Remove-Item -Path $File -Force
     }
 }
 
-function removeDir($dir) {
-    if (![string]::IsNullOrEmpty($dir) -and (Test-Path $dir)) {
-        logmsg "* Removing the directory: ${dir}"
-        Remove-Item -Path $dir -Recurse -Force
+function Remove-Dir {
+    param (
+        $Dir
+    )
+    if (![string]::IsNullOrEmpty($Dir) -and (Test-Path $Dir)) {
+        Write-LogMessage "* Removing the directory: ${Dir}"
+        Remove-Item -Path $Dir -Recurse -Force
     }
 }
 
-function cleanup($contextPaths) {
-    if ($contextPaths.contextDrive) {
+function Remove-Context {
+    param (
+        $ContextPaths
+    )
+    if ($ContextPaths.contextDrive) {
         # Eject CD with 'context.sh' if requested
-        ejectContextCD $contextPaths.contextDrive
+        Dismount-ContextCD $ContextPaths.contextDrive
     }
     else {
         # Delete 'context.sh' if not on CD-ROM
-        removeFile $contextPaths.contextPath
+        Remove-File $ContextPaths.contextPath
 
         # and downloaded init scripts
-        removeDir $contextPaths.contextInitScriptPath
+        Remove-Dir $ContextPaths.contextInitScriptPath
     }
 }
 
-function pswrapper($path) {
+function Invoke-PowerShellWrapper {
+    param (
+        $Path
+    )
     # source:
     #   - http://cosmonautdreams.com/2013/09/03/Getting-Powershell-to-run-in-64-bit.html
     #   - https://ss64.com/nt/syntax-64bit.html
-    If ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64") {
+    if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64") {
         # This is only set in a x86 Powershell running on a 64bit Windows
 
-        $realpath = [string]$(Resolve-Path "$path")
+        $realpath = [string]$(Resolve-Path "$Path")
 
         # Run 64bit powershell as a subprocess and there execute the command
         #
         # NOTE: virtual subdir 'sysnative' exists only when running 32bit binary under 64bit system
         & "$env:WINDIR\sysnative\windowspowershell\v1.0\powershell.exe" -NonInteractive -NoProfile -Command "$realpath"
     }
-    Else {
-        & "$path"
+    else {
+        & "$Path"
     }
 }
 
-function authorizeSSHKeyAdmin {
+function Grant-SSHKeyAdmin {
     param (
-        $authorizedKeys
+        $AuthorizedKeys
     )
 
     $authorizedKeysPath = "$env:ProgramData\ssh\administrators_authorized_keys"
@@ -1322,46 +1377,46 @@ function authorizeSSHKeyAdmin {
 
     $authoriozedKeysDir = Split-Path -Parent -Path $authorizedKeysPath
     if (!(Test-Path $authoriozedKeysDir)) {
-        logmsg "- Directory $authoriozedKeysDir does not exist"
-        logmsg "- Trying to create the directory $authoriozedKeysDir"
+        Write-LogMessage "- Directory $authoriozedKeysDir does not exist"
+        Write-LogMessage "- Trying to create the directory $authoriozedKeysDir"
         New-Item -ItemType Directory -Path $authoriozedKeysDir
         if ($?) {
-            logsuccess
+            Write-LogMessage "  ... Success"
         }
         else {
-            logfail
+            Write-LogMessage "  ... Failed"
         }
     }
 
     # whitelisting
-    logmsg "- Writing SSH key to $authorizedKeysPath"
-    Set-Content $authorizedKeysPath $authorizedKeys
+    Write-LogMessage "- Writing SSH key to $authorizedKeysPath"
+    Set-Content $authorizedKeysPath $AuthorizedKeys
 
     if ($?) {
         # permissions
         icacls.exe $authorizedKeysPath /inheritance:r /grant Administrators:F /grant SYSTEM:F
 
-        logsuccess
+        Write-LogMessage "  ... Success"
     }
     else {
-        logfail
+        Write-LogMessage "  ... Failed"
     }
 
 }
 
-function disableSharedAdminSSHKeys {
+function Disable-SharedAdminSSHKeySet {
     $cfgtoRemoveRegex = ('Match Group administrators\r?\n' + 
                         ' {7}AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys(?:\r?\n)')
     $sshdConfigPath = "$env:PROGRAMDATA\ssh\sshd_config"
     $currentConfig = Get-Content $sshdConfigPath -Raw
     if ($currentConfig -match $cfgtoRemoveRegex) {
         $updatedConfig = $currentConfig -replace $cfgtoRemoveRegex
-        logmsg "- Disabling use of default shared admins_authorized_keys for Administrators group"
+        Write-LogMessage "- Disabling use of default shared admins_authorized_keys for Administrators group"
         Set-Content -Path $sshdConfigPath -Value $updatedConfig
         if ($?) {
-            logsuccess
+            Write-LogMessage "  ... Success"
         } else {
-            logfail
+            Write-LogMessage "  ... Failed"
         }
         $sshdService = Get-Service -Name sshd -ErrorAction SilentlyContinue
         if ($sshdService.Status -eq "Running") {
@@ -1370,60 +1425,60 @@ function disableSharedAdminSSHKeys {
     }
 }
 
-function authorizeSSHKeyStandard {
+function Grant-SSHKeyStandard {
     param (
-        $authorizedKeys,
-        $username
+        $AuthorizedKeys,
+        $Username
     )
-    
+
     # Check if user profile directory exists
-    $userProfilePath = "$env:systemdrive\Users\$username"
+    $userProfilePath = "$env:systemdrive\Users\$Username"
     if ( !(Test-Path $userProfilePath)) {
-        logmsg "  ... Failed (Userprofile directory $userProfilePath does not exists)"
+        Write-LogMessage "  ... Failed (Userprofile directory $userProfilePath does not exists)"
         return
     }
-    
+
     # prepare .ssh folder
     $sshFolderPath = "$userProfilePath\.ssh"
     if ( !(Test-Path $sshFolderPath)) {
-        logmsg "- Creating .ssh folder in $userProfilePath"
+        Write-LogMessage "- Creating .ssh folder in $userProfilePath"
         New-Item -Force -ItemType Directory -Path $sshFolderPath | Out-Null
         if ($?) {
-            logsuccess
+            Write-LogMessage "  ... Success"
         }
         else {
-            logfail
+            Write-LogMessage "  ... Failed"
             return
         }
     }
 
     # write the keys
     $authorizedKeysFilePath = "$userProfilePath\.ssh\authorized_keys"
-    logmsg "- Writing key to $authorizedKeysFilePath"
-    Set-Content -Path $authorizedKeysFilePath -Value $authorizedKeys
+    Write-LogMessage "- Writing key to $authorizedKeysFilePath"
+    Set-Content -Path $authorizedKeysFilePath -Value $AuthorizedKeys
     if ($?) {
-        logsuccess
+        Write-LogMessage "  ... Success"
     }
     else {
-        logfail
+        Write-LogMessage "  ... Failed"
     }
 }
 
-function authorizeSSHKey {
+function Grant-SSHKey {
     param (
-        $authorizedKeys,
-        $winadmin,
-        $username
+        $AuthorizedKeys,
+        $WinAdmin,
+        $Username
     )
 
-    logmsg "* Authorizing SSH_PUBLIC_KEY: ${authorizedKeys}"
+    Write-LogMessage "* Authorizing SSH_PUBLIC_KEY: ${AuthorizedKeys}"
 
-    if ($winadmin -ieq "no") {
-        disableSharedAdminSSHKeys
-        authorizeSSHKeyStandard $authorizedKeys $username
+    if ($WinAdmin -ieq "no") {
+        Disable-SharedAdminSSHKeySet
+        Grant-SSHKeyStandard $AuthorizedKeys $Username
     }
     else {
-        authorizeSSHKeyAdmin $authorizedKeys
+        Grant-SSHKeyAdmin $AuthorizedKeys
     }
 
 }
@@ -1436,24 +1491,24 @@ function authorizeSSHKey {
 $global:ctxDir = "$env:SystemDrive\.onecontext"
 
 # Check, if above defined context directory exists
-If ( !(Test-Path "$ctxDir") ) {
+if ( !(Test-Path "$ctxDir") ) {
     mkdir "$ctxDir"
 }
 
 # Delete .old log file (if exist) - simple rotation
-If (Test-Path "$ctxDir\opennebula-context-old.log") {
+if (Test-Path "$ctxDir\opennebula-context-old.log") {
     Remove-Item "$ctxDir\opennebula-context-old.log"
 }
 
 # Move last logfile away - so we have a current log containing the output of the last boot
-If ( Test-Path "$ctxDir\opennebula-context.log" ) {
+if ( Test-Path "$ctxDir\opennebula-context.log" ) {
     mv "$ctxDir\opennebula-context.log" "$ctxDir\opennebula-context-old.log"
 }
 
 # Start now logging to logfile
 Start-Transcript -Append -Path "$ctxDir\opennebula-context.log" | Out-Null
 
-logmsg "* Running Script: $($MyInvocation.MyCommand.Path)"
+Write-LogMessage "* Running Script: $($MyInvocation.MyCommand.Path)"
 
 Set-ExecutionPolicy unrestricted -Force # not needed if already done once on the VM
 [string]$computerName = "$env:computername"
@@ -1461,7 +1516,7 @@ Set-ExecutionPolicy unrestricted -Force # not needed if already done once on the
 
 # Check the working WMI
 if (-Not (Get-WMIObject -ErrorAction SilentlyContinue Win32_Volume)) {
-    logmsg "- WMI not ready, exiting"
+    Write-LogMessage "- WMI not ready, exiting"
     Stop-Transcript | Out-Null
     exit 1
 }
@@ -1476,33 +1531,33 @@ Write-Host "`r`n" -NoNewline
 $checksum = ""
 do {
     # Stay in this wait-loop until context.sh emerges and its path is stored
-    $contextPaths = waitForContext($checksum)
+    $contextPaths = Wait-ForContext($checksum)
 
     # Parse context file
-    $context = getContext $contextPaths.contextScriptPath
+    $context = Get-ContextData $contextPaths.contextScriptPath
 
     # Execute the contextualization actions
-    extendPartitions $context
-    setTimeZone $context
-    addLocalUser $context
-    enableRemoteDesktop
-    enableSSH
-    enablePing
-    configureNetwork $context
-    renameComputer $context
-    runScripts $context $contextPaths
-    authorizeSSHKey $context["SSH_PUBLIC_KEY"] $context["WINADMIN"] $context["USERNAME"]
-    reportReady $context $contextPaths.contextLetter
+    Resize-PartitionSet $context
+    Set-TimeZone $context
+    Add-LocalUser $context
+    Enable-RemoteDesktop
+    Enable-SSH
+    Enable-Ping
+    Set-NetworkConfiguration $context
+    Rename-Computer $context
+    Invoke-ScriptSetExecution $context $contextPaths
+    Grant-SSHKey $context["SSH_PUBLIC_KEY"] $context["WINADMIN"] $context["USERNAME"]
+    Invoke-ReportReady $context $contextPaths.contextLetter
 
     # Save the 'applied' context.sh checksum for the next recontextualization
-    logmsg "* Calculating the checksum of the file: $($contextPaths.contextScriptPath)"
+    Write-LogMessage "* Calculating the checksum of the file: $($contextPaths.contextScriptPath)"
     $checksum = Get-FileHash -Algorithm SHA256 $contextPaths.contextScriptPath
-    logmsg "  ... $($checksum.Hash)"
+    Write-LogMessage "  ... $($checksum.Hash)"
     # and remove the file itself
-    removeFile $contextPaths.contextScriptPath
+    Remove-File $contextPaths.contextScriptPath
 
     # Cleanup at the end
-    cleanup $contextPaths
+    Remove-Context $contextPaths
 
     Write-Host "`r`n" -NoNewline
 


### PR DESCRIPTION
This PR reformats the Windows context script to align with the style guide defined by Microsoft.

- Function names follow the format: ` <ApprovedVerb>-<Prefix><SingularNoun>` 
- Input parameter names use Pascal Case, and local variables follow Camel Case.