### PR TITLE
M #-: Reformat changes from #152 and add ENABLE_SSH context variable 

### DIFF
--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -1474,23 +1474,21 @@ function Grant-SSHKey {
 
     Write-LogMessage "* Authorizing SSH_PUBLIC_KEY: ${AuthorizedKeys}"
 
-    if (${AuthorizedKeys} -ne $null -and ${AuthorizedKeys} -ne "") {
-        if ($EnableSSHService -ieq "no") {
-            Write-LogMessage "- ENABLE_SSH set to 'NO', skipping SSH service configuration"
-            return
-        }
-
-        Enable-SSH
-        if ($WinAdmin -ieq "no") {
-            Disable-SharedAdminSSHKeySet
-            Grant-SSHKeyStandard $AuthorizedKeys $Username
-        }
-        else {
-            Grant-SSHKeyAdmin $AuthorizedKeys
-        }
+    if ($EnableSSHService -ieq "no") {
+        Write-LogMessage "- ENABLE_SSH set to 'NO', skipping SSH service configuration"
+        return
     }
-    else {
+    if (${AuthorizedKeys} -eq $null -or ${AuthorizedKeys} -eq "") {
         Write-LogMessage "- No SSH_PUBLIC_KEY provided, skipping"
+        return
+    }
+
+    Enable-SSH
+    if ($WinAdmin -ieq "no") {
+        Disable-SharedAdminSSHKeySet
+        Grant-SSHKeyStandard $AuthorizedKeys $Username
+    } else {
+        Grant-SSHKeyAdmin $AuthorizedKeys
     }
 }
 

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -967,14 +967,14 @@ function Enable-SSH {
 function Enable-Ping {
     Write-LogMessage "* Enabling Ping"
     #Create firewall manager object
-    New-Object -com hnetcfg.fwmgr
+    $fwMgr = New-Object -ComObject HNetCfg.FwMgr
 
     # Get current profile
-    $pro = $fwmgcalPolicy.CurrentProfile
+    $profile = $fwMgr.LocalPolicy.CurrentProfile
 
-    Write-LogMessage "- Enable Allow Inbound Echo Requests"
-    $ret = $pro.IcmpSettings.AllowInboundEchoRequest = $true
-    if ($ret) {
+    logmsg "- Enable Allow Inbound Echo Requests"
+    $ret = $profile.IcmpSettings.AllowInboundEchoRequest = $true
+    If ($ret) {
         Write-LogMessage "  ... Success"
     }
     else {
@@ -1474,20 +1474,24 @@ function Grant-SSHKey {
 
     Write-LogMessage "* Authorizing SSH_PUBLIC_KEY: ${AuthorizedKeys}"
 
-    if ($EnableSSHService -ieq "no") {
-        Write-LogMessage "- ENABLE_SSH set to 'NO', skipping SSH service configuration"
-        return
-    }
+    if (${authorizedKeys} -ne $null -and ${authorizedKeys} -ne "") {
+        if ($EnableSSHService -ieq "no") {
+            Write-LogMessage "- ENABLE_SSH set to 'NO', skipping SSH service configuration"
+            return
+        }
 
-    Enable-SSH
-    if ($WinAdmin -ieq "no") {
-        Disable-SharedAdminSSHKeySet
-        Grant-SSHKeyStandard $AuthorizedKeys $Username
+        Enable-SSH
+        if ($WinAdmin -ieq "no") {
+            Disable-SharedAdminSSHKeySet
+            Grant-SSHKeyStandard $AuthorizedKeys $Username
+        }
+        else {
+            Grant-SSHKeyAdmin $AuthorizedKeys
+        }
     }
     else {
-        Grant-SSHKeyAdmin $AuthorizedKeys
+        logmsg "- No SSH_PUBLIC_KEY provided, skipping"
     }
-
 }
 
 ################################################################################

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -972,9 +972,9 @@ function Enable-Ping {
     # Get current profile
     $profile = $fwMgr.LocalPolicy.CurrentProfile
 
-    logmsg "- Enable Allow Inbound Echo Requests"
+    Write-LogMessage "- Enable Allow Inbound Echo Requests"
     $ret = $profile.IcmpSettings.AllowInboundEchoRequest = $true
-    If ($ret) {
+    if ($ret) {
         Write-LogMessage "  ... Success"
     }
     else {
@@ -1474,7 +1474,7 @@ function Grant-SSHKey {
 
     Write-LogMessage "* Authorizing SSH_PUBLIC_KEY: ${AuthorizedKeys}"
 
-    if (${authorizedKeys} -ne $null -and ${authorizedKeys} -ne "") {
+    if (${AuthorizedKeys} -ne $null -and ${AuthorizedKeys} -ne "") {
         if ($EnableSSHService -ieq "no") {
             Write-LogMessage "- ENABLE_SSH set to 'NO', skipping SSH service configuration"
             return
@@ -1490,7 +1490,7 @@ function Grant-SSHKey {
         }
     }
     else {
-        logmsg "- No SSH_PUBLIC_KEY provided, skipping"
+        Write-LogMessage "- No SSH_PUBLIC_KEY provided, skipping"
     }
 }
 

--- a/context-windows/src/context.ps1
+++ b/context-windows/src/context.ps1
@@ -1468,11 +1468,18 @@ function Grant-SSHKey {
     param (
         $AuthorizedKeys,
         $WinAdmin,
-        $Username
+        $Username,
+        $EnableSSHService
     )
 
     Write-LogMessage "* Authorizing SSH_PUBLIC_KEY: ${AuthorizedKeys}"
 
+    if ($EnableSSHService -ieq "no") {
+        Write-LogMessage "- ENABLE_SSH set to 'NO', skipping SSH service configuration"
+        return
+    }
+
+    Enable-SSH
     if ($WinAdmin -ieq "no") {
         Disable-SharedAdminSSHKeySet
         Grant-SSHKeyStandard $AuthorizedKeys $Username
@@ -1541,12 +1548,11 @@ do {
     Set-TimeZone $context
     Add-LocalUser $context
     Enable-RemoteDesktop
-    Enable-SSH
     Enable-Ping
     Set-NetworkConfiguration $context
     Rename-Computer $context
     Invoke-ScriptSetExecution $context $contextPaths
-    Grant-SSHKey $context["SSH_PUBLIC_KEY"] $context["WINADMIN"] $context["USERNAME"]
+    Grant-SSHKey $context["SSH_PUBLIC_KEY"] $context["WINADMIN"] $context["USERNAME"] $context["ENABLE_SSH"]
     Invoke-ReportReady $context $contextPaths.contextLetter
 
     # Save the 'applied' context.sh checksum for the next recontextualization


### PR DESCRIPTION
Originally introduced in #152  thank you so much @DeBuXer ❤️

-  Reformats syntax in the Enable-Ping function to comply with Microsfot style guide.
-  Introduces a new context variable ENABLE_SSH, which allows disabling the behavior added in #156.