### PR TITLE
M #-: Various Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.SECONDEXPANSION:
+
 # load variables and makefile config
 include Makefile.config
 
@@ -5,80 +7,82 @@ include Makefile.config
 -include Makefile.local
 
 # aliases
-distros-amd64: $(patsubst %, packer-%, $(DISTROS_AMD64))
-distros-arm64: $(patsubst %, packer-%, $(DISTROS_ARM64))
-services-amd64: $(patsubst %, packer-%, $(SERVICES_AMD64))
-services-arm64: $(patsubst %, packer-%, $(SERVICES_ARM64))
+distros-amd64: $(DISTROS_AMD64:%=packer-%)
+distros-arm64: $(DISTROS_ARM64:%=packer-%)
+services-amd64: $(SERVICES_AMD64:%=packer-%)
+services-arm64: $(SERVICES_ARM64:%=packer-%)
 
 # allow individual distribution targets (e.g., "make debian11")
-$(DISTROS) $(SERVICES):  %: packer-% ;
+$(DISTROS) $(SERVICES): %: packer-%
 
 # aliases + dependency
-packer-%: ${DIR_EXPORT}/%.qcow2
-	@${INFO} "Packer ${*} done"
+packer-%: $(DIR_EXPORT)/%.qcow2
+	@$(INFO) "Packer $* done"
 
-packer-service_Wordpress: packer-alma8 ${DIR_EXPORT}/service_Wordpress.qcow2
-	@${INFO} "Packer service_Wordpress done"
+packer-service_Wordpress: packer-alma8 $(DIR_EXPORT)/service_Wordpress.qcow2
+	@$(INFO) "Packer service_Wordpress done"
 
 # Define if your appliance depends on a distro. This example builds on top of alma8 packer build
-packer-service_example: packer-alma8 ${DIR_EXPORT}/service_example.qcow2
-	@${INFO} "Packer service_example done"
+packer-service_example: packer-alma8 $(DIR_EXPORT)/service_example.qcow2
+	@$(INFO) "Packer service_example done"
 
-packer-service_VRouter: packer-alpine320 ${DIR_EXPORT}/service_VRouter.qcow2
-	@${INFO} "Packer service_VRouter done"
+packer-service_VRouter: packer-alpine320 $(DIR_EXPORT)/service_VRouter.qcow2
+	@$(INFO) "Packer service_VRouter done"
 
-packer-service_VRouter.aarch64: packer-alpine320.aarch64 ${DIR_EXPORT}/service_VRouter.aarch64.qcow2
-	@${INFO} "Packer service_VRouter.aarch64 done"
+packer-service_VRouter.aarch64: packer-alpine320.aarch64 $(DIR_EXPORT)/service_VRouter.aarch64.qcow2
+	@$(INFO) "Packer service_VRouter.aarch64 done"
 
-packer-service_Harbor: packer-ubuntu2204 ${DIR_EXPORT}/service_Harbor.qcow2
-	@${INFO} "Packer service_Harbor done"
+packer-service_Harbor: packer-ubuntu2204 $(DIR_EXPORT)/service_Harbor.qcow2
+	@$(INFO) "Packer service_Harbor done"
 
-packer-service_MinIO: packer-ubuntu2204 ${DIR_EXPORT}/service_MinIO.qcow2
-	@${INFO} "Packer service_MinIO done"
+packer-service_MinIO: packer-ubuntu2204 $(DIR_EXPORT)/service_MinIO.qcow2
+	@$(INFO) "Packer service_MinIO done"
 
-packer-service_OneKE: packer-ubuntu2204oneke ${DIR_EXPORT}/service_OneKE.qcow2 ${DIR_EXPORT}/service_OneKE_storage.qcow2
-	@${INFO} "Packer service_OneKE done"
+packer-service_OneKE: packer-ubuntu2204oneke $(DIR_EXPORT)/service_OneKE.qcow2 $(DIR_EXPORT)/service_OneKE_storage.qcow2
+	@$(INFO) "Packer service_OneKE done"
 
 # airgapped version
 packer-service_OneKEa: PKR_VAR_airgapped := YES
-packer-service_OneKEa: packer-ubuntu2204oneke ${DIR_EXPORT}/service_OneKEa.qcow2 ${DIR_EXPORT}/service_OneKE_storage.qcow2
-	@${INFO} "Packer service_OneKEa done"
+packer-service_OneKEa: packer-ubuntu2204oneke $(DIR_EXPORT)/service_OneKEa.qcow2 $(DIR_EXPORT)/service_OneKE_storage.qcow2
+	@$(INFO) "Packer service_OneKEa done"
 
-packer-service_Ray: packer-ubuntu2204 ${DIR_EXPORT}/service_Ray.qcow2
-	@${INFO} "Packer service_Ray done"
+packer-service_Ray: packer-ubuntu2204 $(DIR_EXPORT)/service_Ray.qcow2
+	@$(INFO) "Packer service_Ray done"
 
 # run packer build for given distro or service
-${DIR_EXPORT}/service_OneKE_storage.qcow2:
-	qemu-img create -f qcow2 ${DIR_EXPORT}/service_OneKE_storage.qcow2 10G
-	@${INFO} "Packer service_OneKE_storage done"
+$(DIR_EXPORT)/service_OneKE_storage.qcow2:
+	qemu-img create -f qcow2 $(DIR_EXPORT)/service_OneKE_storage.qcow2 10G
+	@$(INFO) "Packer service_OneKE_storage done"
 
-${DIR_EXPORT}/%.qcow2: $(patsubst %, context-linux/out/%, $(LINUX_CONTEXT_PACKAGES))
-	$(eval DISTRO_NAME := $(shell echo ${*} | sed 's/[0-9\.].*//'))
-	$(eval DISTRO_VER  := $(shell echo ${*} | sed 's/^.[^0-9\.]*\(.*\)/\1/'))
-	packer/build.sh "${DISTRO_NAME}" "${DISTRO_VER}" ${@}
+$(DIR_EXPORT)/%.qcow2: PREREQ_linux   := $(LINUX_CONTEXT_PACKAGES_FULL)
+$(DIR_EXPORT)/%.qcow2: PREREQ_windows := $(WINDOWS_CONTEXT_PACKAGES_FULL)
+$(DIR_EXPORT)/%.qcow2: $$(PREREQ_$$(or $$(findstring windows,$$*),linux))
+	$(eval DISTRO_NAME := $(shell echo $* | sed 's/[0-9\.].*//'))
+	$(eval DISTRO_VER  := $(shell echo $* | sed 's/^.[^0-9\.]*\(.*\)/\1/'))
+	packer/build.sh '$(DISTRO_NAME)' '$(DISTRO_VER)' $@
 
 # context packages
-context-linux: $(patsubst %, context-linux/out/%, $(LINUX_CONTEXT_PACKAGES))
-	@${INFO} "Generate context-linux done"
+context-linux: $(LINUX_CONTEXT_PACKAGES_FULL)
+	@$(INFO) "Generate context-linux done"
 
-context-linux/out/%: ${CONTEXT_LINUX_SOURCES}
-	cd context-linux; ./generate-all.sh
+context-linux/out/%: $(CONTEXT_LINUX_SOURCES)
+	cd context-linux/ && ./generate-all.sh
 
-context-windows: $(patsubst %, context-windows/out/%, $(WINDOWS_CONTEXT_PACKAGES))
-	@${INFO} "Generate context-windows done"
+context-windows: $(WINDOWS_CONTEXT_PACKAGES_FULL)
+	@$(INFO) "Generate context-windows done"
 
-context-windows/out/%: ${CONTEXT_WINDOWS_SOURCES}
-	cd context-windows; ./generate-all.sh
+context-windows/out/%: $(CONTEXT_WINDOWS_SOURCES)
+	cd context-windows/ && ./generate-all.sh
 
 # context iso with all the context packages
-context-iso: ${DIR_EXPORT}/one-context-$(VERSION)-$(RELEASE).iso
-${DIR_EXPORT}/one-context-$(VERSION)-$(RELEASE).iso: \
-	$(patsubst %, context-linux/out/%, $(LINUX_CONTEXT_PACKAGES)) \
-	$(patsubst %, context-windows/out/%, $(WINDOWS_CONTEXT_PACKAGES))
-	mkisofs -J -R -input-charset utf8 -m '*.iso' -V one-context-$(VERSION) -o ${DIR_EXPORT}/one-context.iso  context-linux/out/one-context?${VERSION}* context-windows/out/one-context-${VERSION}*.msi
+context-iso: $(DIR_EXPORT)/one-context-$(VERSION)-$(RELEASE).iso
+$(DIR_EXPORT)/one-context-$(VERSION)-$(RELEASE).iso: $(LINUX_CONTEXT_PACKAGES_FULL) $(WINDOWS_CONTEXT_PACKAGES_FULL)
+	mkisofs -J -R -input-charset utf8 -m '*.iso' -V one-context-$(VERSION) -o $(DIR_EXPORT)/one-context.iso \
+	context-linux/out/one-context?$(VERSION)* \
+	context-windows/out/one-context-$(VERSION)*.msi
 
 clean:
-	-rm -rf ${DIR_EXPORT}/*
+	-if [ -d '$(DIR_EXPORT)' ]; then rm -rf $(DIR_EXPORT)/*; fi
 	-rm -rf context-linux/out/*
 	-rm -rf context-windows/out/*
 
@@ -96,19 +100,19 @@ help:
 	@echo '    make context-windows   -- build windows linux packages'
 	@echo
 	@echo 'Available distros (x86_64):'
-	@echo "$(shell echo "${DISTROS_AMD64}" | fmt -w 65 | tr '\n' '\1' )" \
+	@echo "$(shell echo "$(DISTROS_AMD64)" | fmt -w 65 | tr '\n' '\1' )" \
 		           | tr '\1' '\n' | sed 's/^/    /'
 	@echo 'Available distros (aarch64):'
-	@echo "$(shell echo "${DISTROS_ARM64}" | fmt -w 65 | tr '\n' '\1' )" \
+	@echo "$(shell echo "$(DISTROS_ARM64)" | fmt -w 65 | tr '\n' '\1' )" \
 		           | tr '\1' '\n' | sed 's/^/    /'
 	@echo 'Available services (x86_64):'
-	@echo "$(shell echo "${SERVICES_AMD64}" | fmt -w 65 | tr '\n' '\1' )" \
+	@echo "$(shell echo "$(SERVICES_AMD64)" | fmt -w 65 | tr '\n' '\1' )" \
 		           | tr '\1' '\n' | sed 's/^/    /'
 	@echo 'Available services (aarch64):'
 	@echo '    $(SERVICES_ARM64)'
 	@echo
 	@echo 'Available Windows (x86_64):'
-	@echo "$(shell echo "$${WINDOWS:0:45}... see Makefile.config" )"
+	@echo '    $(wordlist 1,2,$(WINDOWS)) ... (see Makefile.config)'
 
 version:
 	@echo $(VERSION)-$(RELEASE) > version

--- a/Makefile.config
+++ b/Makefile.config
@@ -27,39 +27,39 @@ DISTROS_ARM64 := alma8.aarch64 alma9.aarch64 \
                  ubuntu2204.aarch64 ubuntu2404.aarch64
 
 SERVICES_AMD64 := service_Wordpress service_VRouter service_OneKE service_OneKEa \
-				  service_Harbor service_MinIO service_Ray service_example
+                  service_Harbor service_MinIO service_Ray service_example
 
 SERVICES_ARM64 := service_VRouter.aarch64
 
-WINDOWS :=       windows10Home windows10HomeN windows10HomeSingleLanguage \
-                 windows10Pro windows10ProN \
-                 windows10ProWorkstations windows10ProWorkstationsN \
-                 windows10ProEducation windows10ProEducationN \
-                 windows10Education windows10EducationN \
-                 windows10Enterprise windows10EnterpriseN \
-                 windows10EnterpriseLTSC2015 windows10EnterpriseNLTSC2015 \
-                 windows10EnterpriseLTSC2016 windows10EnterpriseNLTSC2016 \
-                 windows10EnterpriseLTSC2019 windows10EnterpriseNLTSC2019 \
-                 windows10EnterpriseLTSC2021 windows10EnterpriseNLTSC2021 \
-                 windows11Home windows11HomeN windows11HomeSingleLanguage \
-                 windows11Pro windows11ProN \
-                 windows11ProWorkstations windows11ProWorkstationsN \
-                 windows11ProEducation windows11ProEducationN \
-                 windows11Education windows11EducationN \
-                 windows11Enterprise windows11EnterpriseN \
-                 windows11EnterpriseLTSC2024 windows11EnterpriseNLTSC2024 \
-                 windows2016Essentials \
-                 windows2016Standard windows2016StandardCore \
-                 windows2016Datacenter windows2016DatacenterCore \
-                 windows2019Essentials \
-                 windows2019Standard windows2019StandardCore \
-                 windows2019Datacenter windows2019DatacenterCore \
-                 windows2022Standard windows2022StandardCore \
-                 windows2022Datacenter windows2022DatacenterCore \
-                 windows2025Standard windows2025StandardCore \
-                 windows2025Datacenter windows2025DatacenterCore
+WINDOWS := windows10Home windows10HomeN windows10HomeSingleLanguage \
+           windows10Pro windows10ProN \
+           windows10ProWorkstations windows10ProWorkstationsN \
+           windows10ProEducation windows10ProEducationN \
+           windows10Education windows10EducationN \
+           windows10Enterprise windows10EnterpriseN \
+           windows10EnterpriseLTSC2015 windows10EnterpriseNLTSC2015 \
+           windows10EnterpriseLTSC2016 windows10EnterpriseNLTSC2016 \
+           windows10EnterpriseLTSC2019 windows10EnterpriseNLTSC2019 \
+           windows10EnterpriseLTSC2021 windows10EnterpriseNLTSC2021 \
+           windows11Home windows11HomeN windows11HomeSingleLanguage \
+           windows11Pro windows11ProN \
+           windows11ProWorkstations windows11ProWorkstationsN \
+           windows11ProEducation windows11ProEducationN \
+           windows11Education windows11EducationN \
+           windows11Enterprise windows11EnterpriseN \
+           windows11EnterpriseLTSC2024 windows11EnterpriseNLTSC2024 \
+           windows2016Essentials \
+           windows2016Standard windows2016StandardCore \
+           windows2016Datacenter windows2016DatacenterCore \
+           windows2019Essentials \
+           windows2019Standard windows2019StandardCore \
+           windows2019Datacenter windows2019DatacenterCore \
+           windows2022Standard windows2022StandardCore \
+           windows2022Datacenter windows2022DatacenterCore \
+           windows2025Standard windows2025StandardCore \
+           windows2025Datacenter windows2025DatacenterCore
 
-DISTROS := $(DISTROS_AMD64) $(DISTROS_ARM64) $(WINDOWS)
+DISTROS  := $(DISTROS_AMD64) $(DISTROS_ARM64) $(WINDOWS)
 SERVICES := $(SERVICES_AMD64) $(SERVICES_ARM64)
 
 .DEFAULT_GOAL := help
@@ -67,39 +67,44 @@ SERVICES := $(SERVICES_AMD64) $(SERVICES_ARM64)
 # default directories
 DIR_BUILD  := build
 DIR_EXPORT := export
-$(shell mkdir -p ${DIR_BUILD} ${DIR_EXPORT})
+$(shell mkdir -p $(DIR_BUILD) $(DIR_EXPORT))
 
 # don't delete exported
-.SECONDARY: $(patsubst %, $(DIR_EXPORT)/%.qcow2, $(DISTROS)) $(patsubst %, $(DIR_EXPORT)/%.qcow2, $(SERVICES))
+.SECONDARY: $(DISTROS:%=$(DIR_EXPORT)/%.qcow2) $(SERVICES:%=$(DIR_EXPORT)/%.qcow2)
 
 .PHONY: context-linux context-windows context-iso help
 
 # this needs to match context-linux/generate-all.sh products
-LINUX_CONTEXT_PACKAGES := one-context_${VERSION}-${RELEASE}.deb \
-    one-context-${VERSION}-${RELEASE}.el8.noarch.rpm \
-    one-context-${VERSION}-${RELEASE}.el9.noarch.rpm \
-    one-context-${VERSION}-${RELEASE}.el10.noarch.rpm \
-    one-context-${VERSION}-${RELEASE}.fc.noarch.rpm \
-    one-context-${VERSION}-${RELEASE}.amzn2.noarch.rpm \
-    one-context-${VERSION}-${RELEASE}.amzn2023.noarch.rpm \
-    one-context-${VERSION}-${RELEASE}.suse.noarch.rpm \
-    one-context-${VERSION}_${RELEASE}.txz \
-    one-context-${VERSION}-alt${RELEASE}.noarch.rpm \
-    one-context-${VERSION}-r${RELEASE}.apk \
-    one-context-linux-${VERSION}-${RELEASE}.iso
+LINUX_CONTEXT_PACKAGES := \
+    one-context_$(VERSION)-$(RELEASE).deb \
+    one-context-$(VERSION)-$(RELEASE).el8.noarch.rpm \
+    one-context-$(VERSION)-$(RELEASE).el9.noarch.rpm \
+    one-context-$(VERSION)-$(RELEASE).el10.noarch.rpm \
+    one-context-$(VERSION)-$(RELEASE).fc.noarch.rpm \
+    one-context-$(VERSION)-$(RELEASE).amzn2.noarch.rpm \
+    one-context-$(VERSION)-$(RELEASE).amzn2023.noarch.rpm \
+    one-context-$(VERSION)-$(RELEASE).suse.noarch.rpm \
+    one-context-$(VERSION)_$(RELEASE).txz \
+    one-context-$(VERSION)-alt$(RELEASE).noarch.rpm \
+    one-context-$(VERSION)-r$(RELEASE).apk \
+    one-context-linux-$(VERSION)-$(RELEASE).iso
 
-LINUX_CONTEXT_PACKAGES_FULL := $(patsubst %, context-linux/out/%, $(LINUX_CONTEXT_PACKAGES))
-CONTEXT_LINUX_SOURCES := $(shell find context-linux/src -type f) context-linux/generate-all.sh  context-linux/generate.sh  context-linux/targets.sh
+LINUX_CONTEXT_PACKAGES_FULL := $(LINUX_CONTEXT_PACKAGES:%=context-linux/out/%)
+
+CONTEXT_LINUX_SOURCES := $(shell find context-linux/src -type f) \
+    context-linux/generate-all.sh context-linux/generate.sh context-linux/targets.sh
 
 # this needs to match context-windows/generate-all.sh products
-WINDOWS_CONTEXT_PACKAGES := one-context-${VERSION}.msi \
-    one-context-${VERSION}.iso
+WINDOWS_CONTEXT_PACKAGES := \
+    one-context-$(VERSION)-$(RELEASE).msi \
+    one-context-$(VERSION)-$(RELEASE).iso
 
-WINDOWS_CONTEXT_PACKAGES_FULL := $(patsubst %, context-windows/out/%, $(WINDOWS_CONTEXT_PACKAGES))
+WINDOWS_CONTEXT_PACKAGES_FULL := $(WINDOWS_CONTEXT_PACKAGES:%=context-windows/out/%)
+
 CONTEXT_WINDOWS_SOURCES := $(shell find context-windows/src -type f)
 
 # logging func
-INFO=sh -c 'if [ $(VERBOSE) = 1 ]; then  echo [INFO] $$1; fi' INFO
+INFO=sh -c 'if [ $(VERBOSE) = 1 ]; then echo [INFO] $$1; fi' INFO
 
 # export all variables
 export


### PR DESCRIPTION
- Use more common () instead of {} (which can be confusing when shell variables are used)
- Use :%= idiom instead of patsubst (takes much less space)
- Make use of (WINDOWS/LINUX)_CONTEXT_PACKAGES_FULL variables (reduce visual complexity)
- Add .SECONDEXPANSION to handle conditional windows/linux context builds
- Make windows/linux context builds fully conditional
- Use correct versioning for windows context artifacts
- Make sure "rm -rf /*" is extra impossible to execute (paranoid)
- Fix help message for windows targets
- Remove unneeded whitespace + convert some "insignificant" tabs to spaces