### PR TITLE
B #-: Alpine fix tty0, drops chrony

### DIFF
--- a/packer/alpine/11-update-boot.sh
+++ b/packer/alpine/11-update-boot.sh
@@ -16,6 +16,7 @@ if [ "$(arch)" = "x86_64" ]; then
 
     gawk -i inplace -f- /etc/update-extlinux.conf <<'EOF'
 /^default_kernel_opts=/ { gsub(/console=ttyS[^ "]*/, "") }
+/^default_kernel_opts=/ { gsub(/console=ttyAMA[^ "]*/, "console=tty0") }
 { print }
 EOF
 fi

--- a/packer/alpine/98-collect-garbage.sh
+++ b/packer/alpine/98-collect-garbage.sh
@@ -8,6 +8,11 @@ set -eux -o pipefail
 apk del cloud-init
 find /etc/runlevels/ -name 'cloud-init*' -delete
 
+# chrony sometimes takes too long to start also delaying sshd
+service chronyd stop
+apk del chrony
+userdel chrony
+
 rm -f /etc/motd
 
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
Although chrony is enabled in cloud images, it sometimes causes long starts and delaying also sshd.