### PR TITLE
M #-: Disable administrator account by default in windows builds

### DIFF
--- a/packer/windows/variables.pkr.hcl
+++ b/packer/windows/variables.pkr.hcl
@@ -33,7 +33,7 @@ variable "iso_files" {
 
 variable "disable_administrator" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to disable the Administrator user after initial setup"
 }
 


### PR DESCRIPTION
Sets the default value for `disable_administrator`  to true in Windows builds