### PR TITLE
B #-: Fixes deleted OneKE ubuntu image

### DIFF
--- a/packer/ubuntu/variables.pkr.hcl
+++ b/packer/ubuntu/variables.pkr.hcl
@@ -63,12 +63,12 @@ variable "ubuntu" {
     }
 
     "2204oneke" = {
-      iso_url      = "https://cloud-images.ubuntu.com/releases/22.04/release-20241206/ubuntu-22.04-server-cloudimg-amd64.img"
-      iso_checksum = "file:https://cloud-images.ubuntu.com/releases/22.04/release-20241206/SHA256SUMS"
+      iso_url      = "https://cloud-images.ubuntu.com/releases/jammy/release-20241206/ubuntu-22.04-server-cloudimg-amd64.img"
+      iso_checksum = "file:https://cloud-images.ubuntu.com/releases/jammy/release-20241206/SHA256SUMS"
     }
     "2204oneke.aarch64" = {
-      iso_url      = "https://cloud-images.ubuntu.com/releases/22.04/release-20241206/ubuntu-22.04-server-cloudimg-arm64.img"
-      iso_checksum = "file:https://cloud-images.ubuntu.com/releases/22.04/release-20241206/SHA256SUMS"
+      iso_url      = "https://cloud-images.ubuntu.com/releases/jammy/release-20241206/ubuntu-22.04-server-cloudimg-arm64.img"
+      iso_checksum = "file:https://cloud-images.ubuntu.com/releases/jammy/release-20241206/SHA256SUMS"
     }
   }
 }


### PR DESCRIPTION
Looks that the 2024 images have been deleted from the ubuntu repository: https://cloud-images.ubuntu.com/releases/22.04/release-20241206/. Canonical recommended us to use the codename url.

Related canonical ticket: https://bugs.launchpad.net/cloud-images/+bug/2100926