### PR TITLE
B #-: Increases oneke ubuntu packed image size to 3G

### DIFF
--- a/packer/ubuntu/ubuntu.pkr.hcl
+++ b/packer/ubuntu/ubuntu.pkr.hcl
@@ -34,7 +34,8 @@ source "qemu" "ubuntu" {
   net_device       = "virtio-net"
   format           = "qcow2"
   disk_compression = false
-  skip_resize_disk = true
+  disk_size        = 3072
+  skip_resize_disk = false
 
   output_directory = var.output_dir
 


### PR DESCRIPTION
The oneke ubuntu packer build failed due to disk space problems on the hard disk, we increased the size to 3GB.