### PR TITLE
B #-: OneKE: Add missing proxy config for joined masters

### DIFF
--- a/appliances/OneKE/kubernetes.rb
+++ b/appliances/OneKE/kubernetes.rb
@@ -267,6 +267,8 @@ def join_master(token, retries = RETRIES, seconds = SECONDS)
     msg :info, 'Prepare rke2-server config'
     file '/etc/rancher/rke2/config.yaml', YAML.dump(server_config), overwrite: true
 
+    configure_rke2_proxy 'master'
+
     # The rke2-server systemd service restarts automatically and eventually joins.
     # If it really cannot join we want to reflect this in OneFlow.
     retries.downto(0).each do |retry_num|


### PR DESCRIPTION
This fixes bug that manifests itself in envionments without normal (NATed) access to Internet. Newly joined masters are unable to initialize, because it's not possible to download required docker images.