### PR TITLE
Remove leftover policy files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ context-linux/*.deb
 context-linux/.vagrant*/
 context-linux/*~bak
 .vscode
+.DS_Store

--- a/packer/build.sh
+++ b/packer/build.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
+
 DISTRO_NAME=$1                           # e.g. debian
 DISTRO_VER=$2                            # e.g. 11
 DISTRO=${DISTRO_NAME}${DISTRO_VER}       # e.g. debian11

--- a/packer/debian/10-upgrade-distro.sh
+++ b/packer/debian/10-upgrade-distro.sh
@@ -2,6 +2,8 @@
 
 # Install required packages and upgrade the distro.
 
+# backup policy file if it exists
+[[ -e /usr/sbin/policy-rc.d ]] && cp /usr/sbin/policy-rc.d /tmp/
 policy_rc_d_disable() (echo "exit 101" >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 policy_rc_d_enable()  (echo "exit 0"   >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 

--- a/packer/debian/98-collect-garbage.sh
+++ b/packer/debian/98-collect-garbage.sh
@@ -13,6 +13,14 @@ apt-get autoremove -y
 
 apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
+if [[ -e /tmp/policy-rc.d ]]; then
+    # restore vanilla policy if it has been backed up
+    cp /tmp/policy-rc.d /usr/sbin/
+else
+    # remove temporary policy if no policy was present initially
+    rm /usr/sbin/policy-rc.d
+fi
+
 rm -f /etc/hostname
 rm -f /etc/network/cloud-ifupdown-helper
 rm -f /etc/network/cloud-interfaces-template

--- a/packer/devuan/10-upgrade-distro.sh.4
+++ b/packer/devuan/10-upgrade-distro.sh.4
@@ -2,6 +2,7 @@
 
 # Install required packages and upgrade the distro.
 
+[[ -e /usr/sbin/policy-rc.d ]] && cp /usr/sbin/policy-rc.d /tmp/
 policy_rc_d_disable() (echo "exit 101" >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 policy_rc_d_enable()  (echo "exit 0"   >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 

--- a/packer/devuan/10-upgrade-distro.sh.5
+++ b/packer/devuan/10-upgrade-distro.sh.5
@@ -2,6 +2,7 @@
 
 # Install required packages and upgrade the distro.
 
+[[ -e /usr/sbin/policy-rc.d ]] && cp /usr/sbin/policy-rc.d /tmp/
 policy_rc_d_disable() (echo "exit 101" >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 policy_rc_d_enable()  (echo "exit 0"   >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 

--- a/packer/devuan/98-collect-garbage.sh
+++ b/packer/devuan/98-collect-garbage.sh
@@ -13,6 +13,14 @@ apt-get autoremove -y
 
 apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
+if [[ -e /tmp/policy-rc.d ]]; then
+    # restore vanilla policy if it has been backed up
+    cp /tmp/policy-rc.d /usr/sbin/
+else
+    # remove temporary policy if no policy was present initially
+    rm /usr/sbin/policy-rc.d
+fi
+
 rm -rf /context/
 
 sync

--- a/packer/service_OneKE/82-configure-context.sh
+++ b/packer/service_OneKE/82-configure-context.sh
@@ -2,6 +2,7 @@
 
 # Configure and enable service context.
 
+[[ -e /usr/sbin/policy-rc.d ]] && cp /usr/sbin/policy-rc.d /tmp/
 policy_rc_d_disable() (echo "exit 101" >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 policy_rc_d_enable()  (echo "exit 0"   >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 
@@ -21,5 +22,13 @@ chown root:root /etc/one-context.d/*
 chmod u=rwx,go=rx /etc/one-context.d/*
 
 policy_rc_d_enable
+
+if [[ -e /tmp/policy-rc.d ]]; then
+    # restore vanilla policy if it has been backed up
+    cp /tmp/policy-rc.d /usr/sbin/
+else
+    # remove temporary policy if no policy was present initially
+    rm /usr/sbin/policy-rc.d
+fi
 
 sync

--- a/packer/ubuntu/10-upgrade-distro.sh
+++ b/packer/ubuntu/10-upgrade-distro.sh
@@ -2,6 +2,7 @@
 
 # Install required packages and upgrade the distro.
 
+[[ -e /usr/sbin/policy-rc.d ]] && cp /usr/sbin/policy-rc.d /tmp/
 policy_rc_d_disable() (echo "exit 101" >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 policy_rc_d_enable()  (echo "exit 0"   >/usr/sbin/policy-rc.d && chmod a+x /usr/sbin/policy-rc.d)
 

--- a/packer/ubuntu/98-collect-garbage.sh
+++ b/packer/ubuntu/98-collect-garbage.sh
@@ -13,6 +13,14 @@ apt-get autoremove -y --purge
 
 apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
+if [[ -e /tmp/policy-rc.d ]]; then
+    # restore vanilla policy if it has been backed up
+    cp /tmp/policy-rc.d /usr/sbin/
+else
+    # remove temporary policy if no policy was present initially
+    rm /usr/sbin/policy-rc.d
+fi
+
 rm -f /etc/sysctl.d/99-cloudimg-ipv6.conf
 
 rm -rf /context/


### PR DESCRIPTION
- Improved build error handling
- Use `common.sh` as a bash library for build process repeated function calling. 
  - This avoids rewriting N times the same `policy_rc_d_disable` and `policy_rc_d_enable` functions for each pair of scripts per distro.

Closes #219 