### PR TITLE
B #-: Fixes onegate requests adding content-type header

### DIFF
--- a/appliances/VRouter/vrouter.rb
+++ b/appliances/VRouter/vrouter.rb
@@ -19,6 +19,7 @@ class OneGate
         @uri   = URI.parse(ENV['ONEGATE_ENDPOINT'])
         @vmid  = ENV['VMID']
         @token = ENV['TOKENTXT']
+        @req_content_type = 'application/json'
 
         @http             = Net::HTTP.new(@uri.host, @uri.port)
         @http.use_ssl     = @uri.scheme == 'https'
@@ -65,6 +66,7 @@ class OneGate
 
         req['X-ONEGATE-VMID']  = @vmid
         req['X-ONEGATE-TOKEN'] = @token
+        req['Content-Type'] = @req_content_type
 
         expect_json ? JSON.parse(@http.request(req).body) : @http.request(req).body
     rescue StandardError => e

--- a/appliances/scripts/net-99-report-ready
+++ b/appliances/scripts/net-99-report-ready
@@ -21,28 +21,15 @@ if [[ -x '/etc/one-appliance/service' ]]; then
     fi
 fi
 
-###
+if ! command -v onegate ; then
+    echo "ERROR: No way to signal READY=YES (onegate binary not found)" >&2
+    exit 1
+fi > /dev/null # this will not drop the error message which goes to stderr
 
-if which onegate >/dev/null 2>&1; then
-    if onegate vm update --data READY=YES; then
-        exit
-    fi
+if onegate vm update --data READY=YES; then
+    echo "Reported READY"
+    exit
 fi
 
-if which curl >/dev/null 2>&1; then
-    if curl -X PUT "$ONEGATE_ENDPOINT/vm" \
-            --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-            --header "X-ONEGATE-VMID: $VMID" \
-            -d READY=YES; then
-        exit
-    fi
-fi
-
-if which wget >/dev/null 2>&1; then
-    if wget --method PUT "$ONEGATE_ENDPOINT/vm" \
-            --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-            --header "X-ONEGATE-VMID: $VMID" \
-            --body-data READY=YES; then
-        exit
-    fi
-fi
+echo "ERROR: Failed to report READY" >&2
+exit 1

--- a/context-linux/src/etc/one-context.d/net-99-report-ready
+++ b/context-linux/src/etc/one-context.d/net-99-report-ready
@@ -32,43 +32,13 @@ fi
 
 ###
 
-if command -v curl ; then
-    _command=curl
-elif command -v wget && ! wget --help 2>&1 | grep -q BusyBox; then
-    _command=wget
-elif command -v onegate ; then
-    _command=onegate
-else
-    echo "ERROR: No way to signal READY=YES (no usable binary)" >&2
+if ! command -v onegate ; then
+    echo "ERROR: No way to signal READY=YES (onegate binary not found)" >&2
     exit 1
 fi > /dev/null # this will not drop the error message which goes to stderr
 
 report_ready() {
-    case "$_command" in
-        curl)
-            curl -X "PUT" "${ONEGATE_ENDPOINT}/vm" \
-                --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-                --header "X-ONEGATE-VMID: $VMID" \
-                --max-time 10 \
-                --insecure \
-                -d "READY=YES"
-            ;;
-        wget)
-            wget --method=PUT "${ONEGATE_ENDPOINT}/vm" \
-                --body-data="READY=YES" \
-                --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-                --header "X-ONEGATE-VMID: $VMID" \
-                --timeout=10 \
-                --no-check-certificate
-            ;;
-        onegate)
-            if command -v timeout >/dev/null; then
-                timeout 10 onegate vm update --data "READY=YES"
-            else
-                onegate vm update --data "READY=YES"
-            fi
-            ;;
-    esac
+    onegate vm update --data "READY=YES"
 }
 
 is_base64() {

--- a/context-linux/src/usr/bin/onegate.rb
+++ b/context-linux/src/usr/bin/onegate.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2022, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2025, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -29,7 +29,7 @@ require 'pp'
 module CloudClient
 
     # OpenNebula version
-    VERSION = '6.6.1'
+    VERSION = '6.10.0'
 
     # #########################################################################
     # Default location for the authentication file
@@ -359,7 +359,8 @@ module OneGate
             'DEPLOYING_NETS'          => 11,
             'UNDEPLOYING_NETS'        => 12,
             'FAILED_DEPLOYING_NETS'   => 13,
-            'FAILED_UNDEPLOYING_NETS' => 14
+            'FAILED_UNDEPLOYING_NETS' => 14,
+            'HOLD'                    => 15
         }
 
         STATE_STR = [
@@ -377,7 +378,8 @@ module OneGate
             'DEPLOYING_NETS',
             'UNDEPLOYING_NETS',
             'FAILED_DEPLOYING_NETS',
-            'FAILED_UNDEPLOYING_NETS'
+            'FAILED_UNDEPLOYING_NETS',
+            'HOLD'
         ]
 
         # Returns the string representation of the service state
@@ -448,6 +450,8 @@ module OneGate
             @user_agent = "OpenNebula #{CloudClient::VERSION} " <<
                 "(#{opts[:user_agent]||"Ruby"})"
 
+            @req_content_type = opts[:req_content_type] || "application/json"
+
             @host = nil
             @port = nil
 
@@ -505,6 +509,7 @@ module OneGate
             req['User-Agent'] = @user_agent
             req['X-ONEGATE-TOKEN'] = @token
             req['X-ONEGATE-VMID'] = @vmid
+            req['Content-Type'] = @req_content_type
 
             res = CloudClient::http_start(@uri, @timeout) do |http|
                 http.request(req)
@@ -558,32 +563,26 @@ module OneGate
 
     def self.help_str
         return <<-EOT
-Available commands
-    $ onegate vm show [VMID] [--json]
+## COMMANDS
 
-    $ onegate vm update [VMID] --data KEY=VALUE\\nKEY2=VALUE2
-
-    $ onegate vm update [VMID] --erase KEY
-
-    $ onegate vm ACTION VMID
-        $ onegate resume [VMID]
-        $ onegate stop [VMID]
-        $ onegate suspend [VMID]
-        $ onegate terminate [VMID] [--hard]
-        $ onegate reboot [VMID] [--hard]
-        $ onegate poweroff [VMID] [--hard]
-        $ onegate resched [VMID]
-        $ onegate unresched [VMID]
-        $ onegate hold [VMID]
-        $ onegate release [VMID]
-
-    $ onegate service show [--json][--extended]
-
-    $ onegate service scale --role ROLE --cardinality CARDINALITY
-
-    $ onegate vrouter show [--json]
-
-    $ onegate vnet show VNETID [--json][--extended]
+    * onegate vm show [VMID] [--json]
+    * onegate vm update [VMID] --data KEY=VALUE\\nKEY2=VALUE2
+    * onegate vm update [VMID] --erase KEY
+    * onegate vm ACTION VMID
+        * onegate resume [VMID]
+        * onegate stop [VMID]
+        * onegate suspend [VMID]
+        * onegate terminate [VMID] [--hard]
+        * onegate reboot [VMID] [--hard]
+        * onegate poweroff [VMID] [--hard]
+        * onegate resched [VMID]
+        * onegate unresched [VMID]
+        * onegate hold [VMID]
+        * onegate release [VMID]
+    * onegate service show [--json][--extended]
+    * onegate service scale --role ROLE --cardinality CARDINALITY
+    * onegate vrouter show [--json]
+    * onegate vnet show VNETID [--json][--extended]
 EOT
     end
 end
@@ -815,3 +814,4 @@ else
     STDERR.puts OneGate.help_str
     exit -1
 end
+


### PR DESCRIPTION
* Adds `Content-type: application/json` header to onegate requests for fixing them.
* Removes curl and wget as fallback methods for reporting readiness to onegate (unify interface to onegate client). 