### PR TITLE
B #-: Fixes onegate client vm update method

### DIFF
--- a/appliances/VRouter/vrouter.rb
+++ b/appliances/VRouter/vrouter.rb
@@ -53,8 +53,9 @@ class OneGate
 
     def vm_update(data, vmid = nil, erase: false, keep_alive: false)
         path     = vmid.nil? ? '/vm' : "/vms/#{vmid}"
+        type     = erase ? 2 : 1 # 1 = update, 2 = delete_element -> https://github.com/OpenNebula/one-ee/blob/7299692415b6bdf9acb6e7789ec241e1b93adb59/src/onegate/onegate-server.rb#L589-L593
         req      = Net::HTTP::Put.new(path)
-        req.body = erase ? URI.encode_www_form('type' => 2, 'data' => data) : data
+        req.body = URI.encode_www_form('type' => type, 'data' => data)
         do_request req, keep_alive, expect_json: false
     end
 

--- a/appliances/scripts/net-99-report-ready
+++ b/appliances/scripts/net-99-report-ready
@@ -21,28 +21,15 @@ if [[ -x '/etc/one-appliance/service' ]]; then
     fi
 fi
 
-###
+if ! command -v onegate ; then
+    echo "ERROR: No way to signal READY=YES (onegate binary not found)" >&2
+    exit 1
+fi > /dev/null # this will not drop the error message which goes to stderr
 
-if which onegate >/dev/null 2>&1; then
-    if onegate vm update --data READY=YES; then
-        exit
-    fi
+if onegate vm update --data READY=YES; then
+    echo "Reported READY"
+    exit
 fi
 
-if which curl >/dev/null 2>&1; then
-    if curl -X PUT "$ONEGATE_ENDPOINT/vm" \
-            --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-            --header "X-ONEGATE-VMID: $VMID" \
-            -d READY=YES; then
-        exit
-    fi
-fi
-
-if which wget >/dev/null 2>&1; then
-    if wget --method PUT "$ONEGATE_ENDPOINT/vm" \
-            --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-            --header "X-ONEGATE-VMID: $VMID" \
-            --body-data READY=YES; then
-        exit
-    fi
-fi
+echo "ERROR: Failed to report READY" >&2
+exit 1

--- a/context-linux/src/etc/one-context.d/net-99-report-ready
+++ b/context-linux/src/etc/one-context.d/net-99-report-ready
@@ -32,43 +32,13 @@ fi
 
 ###
 
-if command -v curl ; then
-    _command=curl
-elif command -v wget && ! wget --help 2>&1 | grep -q BusyBox; then
-    _command=wget
-elif command -v onegate ; then
-    _command=onegate
-else
-    echo "ERROR: No way to signal READY=YES (no usable binary)" >&2
+if ! command -v onegate ; then
+    echo "ERROR: No way to signal READY=YES (onegate binary not found)" >&2
     exit 1
 fi > /dev/null # this will not drop the error message which goes to stderr
 
 report_ready() {
-    case "$_command" in
-        curl)
-            curl -X "PUT" "${ONEGATE_ENDPOINT}/vm" \
-                --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-                --header "X-ONEGATE-VMID: $VMID" \
-                --max-time 10 \
-                --insecure \
-                -d "READY=YES"
-            ;;
-        wget)
-            wget --method=PUT "${ONEGATE_ENDPOINT}/vm" \
-                --body-data="READY=YES" \
-                --header "X-ONEGATE-TOKEN: $TOKENTXT" \
-                --header "X-ONEGATE-VMID: $VMID" \
-                --timeout=10 \
-                --no-check-certificate
-            ;;
-        onegate)
-            if command -v timeout >/dev/null; then
-                timeout 10 onegate vm update --data "READY=YES"
-            else
-                onegate vm update --data "READY=YES"
-            fi
-            ;;
-    esac
+    onegate vm update --data "READY=YES"
 }
 
 is_base64() {


### PR DESCRIPTION
This solves encoding problems when doing a vm template update with onegate client and vrouter onegate module.

Also, simplifies the report-ready context script.