### PR TITLE
F #229: Add ability to force API source for LB in VRouter

### DIFF
--- a/appliances/VRouter/HAProxy/execute.rb
+++ b/appliances/VRouter/HAProxy/execute.rb
@@ -17,7 +17,7 @@ module HAProxy
 
         static = backends.from_env(prefix: 'ONEAPP_VNF_HAPROXY_LB')
 
-        dynamic = VROUTER_ID.nil? ? backends.from_vms(objects, prefix: 'ONEGATE_HAPROXY_LB', id: SERVICE_ID)
+        dynamic = oneflow_api?(SERVICE_ID) ? backends.from_vms(objects, prefix: 'ONEGATE_HAPROXY_LB', id: SERVICE_ID)
                                   : backends.from_vnets(objects, prefix: 'ONEGATE_HAPROXY_LB', id: VROUTER_ID)
 
         # Replace all "<ETHx_IPy>", "<ETHx_VIPy>" and "<ETHx_EPy>" placeholders where possible.

--- a/appliances/VRouter/HAProxy/execute.rb
+++ b/appliances/VRouter/HAProxy/execute.rb
@@ -17,7 +17,7 @@ module HAProxy
 
         static = backends.from_env(prefix: 'ONEAPP_VNF_HAPROXY_LB')
 
-        dynamic = oneflow_api?(SERVICE_ID) ? backends.from_vms(objects, prefix: 'ONEGATE_HAPROXY_LB', id: SERVICE_ID)
+        dynamic = oneflow_api? ? backends.from_vms(objects, prefix: 'ONEGATE_HAPROXY_LB', id: SERVICE_ID)
                                   : backends.from_vnets(objects, prefix: 'ONEGATE_HAPROXY_LB', id: VROUTER_ID)
 
         # Replace all "<ETHx_IPy>", "<ETHx_VIPy>" and "<ETHx_EPy>" placeholders where possible.

--- a/appliances/VRouter/HAProxy/main.rb
+++ b/appliances/VRouter/HAProxy/main.rb
@@ -16,6 +16,8 @@ module HAProxy
 
     ONEAPP_VNF_HAPROXY_INTERFACES = env :ONEAPP_VNF_HAPROXY_INTERFACES, '' # nil -> none, empty -> all
 
+    ONEAPP_VNF_ONEGATE_LB_API = env :ONEAPP_VNF_ONEGATE_LB_API, 'auto'
+
     def install(initdir: '/etc/init.d')
         msg :info, 'HAProxy::install'
 

--- a/appliances/VRouter/HAProxy/main.rb
+++ b/appliances/VRouter/HAProxy/main.rb
@@ -16,7 +16,7 @@ module HAProxy
 
     ONEAPP_VNF_HAPROXY_INTERFACES = env :ONEAPP_VNF_HAPROXY_INTERFACES, '' # nil -> none, empty -> all
 
-    ONEAPP_VNF_ONEGATE_LB_API = env :ONEAPP_VNF_ONEGATE_LB_API, 'auto'
+    ONEAPP_VNF_LB_ONEGATE_API = env :ONEAPP_VNF_LB_ONEGATE_API, 'auto'
 
     def install(initdir: '/etc/init.d')
         msg :info, 'HAProxy::install'

--- a/appliances/VRouter/HAProxy/tests.rb
+++ b/appliances/VRouter/HAProxy/tests.rb
@@ -38,13 +38,13 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_HAPROXY_LB1_SERVER1_HOST'] = '10.2.200.20'
         ENV['ONEAPP_VNF_HAPROXY_LB1_SERVER1_PORT'] = '54321'
 
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = ''
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = ''
 
         load './main.rb'; include Service::HAProxy
 
         expect(Service::HAProxy::ONEAPP_VNF_HAPROXY_ENABLED).to be true
         expect(Service::HAProxy::ONEAPP_VNF_HAPROXY_REFRESH_RATE).to eq '30'
-        expect(Service::HAProxy::ONEAPP_VNF_ONEGATE_LB_API).to eq 'auto'
+        expect(Service::HAProxy::ONEAPP_VNF_LB_ONEGATE_API).to eq 'auto'
 
         Service::HAProxy.const_set :VROUTER_ID, '86'
 
@@ -157,7 +157,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_HAPROXY_LB1_PORT'] = '8686'
 
         # Internally forced to 'VROUTER' since not in OneFlow
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'service'
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'service'
 
         (vnets ||= []) << JSON.parse(<<~'VNET0')
             {
@@ -290,7 +290,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_HAPROXY_LB1_IP'] = '10.2.11.86'
         ENV['ONEAPP_VNF_HAPROXY_LB1_PORT'] = '4321'
 
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'auto'
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'auto'
 
         (vms ||= []) << JSON.parse(<<~'VM0')
             {
@@ -452,7 +452,7 @@ RSpec.describe self do
       ENV['ONEAPP_VNF_HAPROXY_LB0_SERVER0_HOST'] = '10.2.11.200'
       ENV['ONEAPP_VNF_HAPROXY_LB0_SERVER0_PORT'] = '1234'
 
-      ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'vrouter'
+      ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'vrouter'
 
       (vnets ||= []) << JSON.parse(<<~'VNET0')
           {

--- a/appliances/VRouter/HAProxy/tests.rb
+++ b/appliances/VRouter/HAProxy/tests.rb
@@ -291,6 +291,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_HAPROXY_LB1_PORT'] = '4321'
 
         ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'auto'
+        ENV['SERVICE_ID'] = '123'
 
         (vms ||= []) << JSON.parse(<<~'VM0')
             {

--- a/appliances/VRouter/HAProxy/tests.rb
+++ b/appliances/VRouter/HAProxy/tests.rb
@@ -38,10 +38,13 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_HAPROXY_LB1_SERVER1_HOST'] = '10.2.200.20'
         ENV['ONEAPP_VNF_HAPROXY_LB1_SERVER1_PORT'] = '54321'
 
+        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = ''
+
         load './main.rb'; include Service::HAProxy
 
         expect(Service::HAProxy::ONEAPP_VNF_HAPROXY_ENABLED).to be true
         expect(Service::HAProxy::ONEAPP_VNF_HAPROXY_REFRESH_RATE).to eq '30'
+        expect(Service::HAProxy::ONEAPP_VNF_ONEGATE_LB_API).to eq 'auto'
 
         Service::HAProxy.const_set :VROUTER_ID, '86'
 
@@ -152,6 +155,9 @@ RSpec.describe self do
 
         ENV['ONEAPP_VNF_HAPROXY_LB1_IP'] = '10.2.11.86'
         ENV['ONEAPP_VNF_HAPROXY_LB1_PORT'] = '8686'
+
+        # Internally forced to 'VROUTER' since not in OneFlow
+        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'service'
 
         (vnets ||= []) << JSON.parse(<<~'VNET0')
             {
@@ -283,6 +289,8 @@ RSpec.describe self do
 
         ENV['ONEAPP_VNF_HAPROXY_LB1_IP'] = '10.2.11.86'
         ENV['ONEAPP_VNF_HAPROXY_LB1_PORT'] = '4321'
+
+        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'auto'
 
         (vms ||= []) << JSON.parse(<<~'VM0')
             {
@@ -429,4 +437,100 @@ RSpec.describe self do
             expect(result.strip).to eq output.strip
         end
     end
+
+  it 'should render servers.cfg using VR API (dynamic/OneFlow)' do
+      clear_env
+
+      ENV['ONEAPP_VNF_HAPROXY_ENABLED'] = 'YES'
+      ENV['ONEAPP_VNF_HAPROXY_ONEGATE_ENABLED'] = 'YES'
+
+      ENV['ONEAPP_VNF_HAPROXY_REFRESH_RATE'] = ''
+
+      ENV['ONEAPP_VNF_HAPROXY_LB0_IP'] = '10.2.11.86'
+      ENV['ONEAPP_VNF_HAPROXY_LB0_PORT'] = '6969'
+
+      ENV['ONEAPP_VNF_HAPROXY_LB0_SERVER0_HOST'] = '10.2.11.200'
+      ENV['ONEAPP_VNF_HAPROXY_LB0_SERVER0_PORT'] = '1234'
+
+      ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'vrouter'
+
+      (vnets ||= []) << JSON.parse(<<~'VNET0')
+          {
+            "VNET": {
+              "ID": "0",
+              "AR_POOL": {
+                "AR": [
+                  {
+                    "AR_ID": "0",
+                    "LEASES": {
+                      "LEASE": [
+                        {
+                          "IP": "10.2.11.201",
+                          "MAC": "02:00:0a:02:0b:ca",
+                          "VM": "167",
+                          "NIC_NAME": "NIC0",
+                          "BACKEND": "YES",
+
+                          "ONEGATE_HAPROXY_LB0_IP": "10.2.11.86",
+                          "ONEGATE_HAPROXY_LB0_PORT": "6969",
+                          "ONEGATE_HAPROXY_LB0_SERVER_HOST": "10.2.11.201",
+                          "ONEGATE_HAPROXY_LB0_SERVER_PORT": "1234",
+                          "ONEGATE_HAPROXY_LB0_SERVER_WEIGHT": "1"
+                        },
+                        {
+                          "IP": "10.2.11.200",
+                          "MAC": "02:00:0a:02:0b:c8",
+                          "VM": "167",
+                          "NIC_NAME": "NIC0",
+                          "BACKEND": "YES",
+
+                          "ONEGATE_HAPROXY_LB0_IP": "10.2.11.86",
+                          "ONEGATE_HAPROXY_LB0_PORT": "6969",
+                          "ONEGATE_HAPROXY_LB0_SERVER_HOST": "10.2.11.200",
+                          "ONEGATE_HAPROXY_LB0_SERVER_PORT": "1234",
+                          "ONEGATE_HAPROXY_LB0_SERVER_WEIGHT": "1"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+      VNET0
+
+      load './main.rb'; include Service::HAProxy
+
+      Service::HAProxy.const_set :VROUTER_ID, '87'
+      Service::HAProxy.const_set :SERVICE_ID, '124'
+
+      allow(Service::HAProxy).to receive(:detect_nics).and_return(%w[eth0 eth1 eth2 eth3])
+      allow(Service::HAProxy).to receive(:addrs_to_nics).and_return({
+          '10.2.11.86' => ['eth0']
+      })
+
+      clear_vars Service::HAProxy
+
+      output = <<~'DYNAMIC'
+          frontend lb0_6969
+              mode tcp
+              bind 10.2.11.86:6969
+              default_backend lb0_6969
+
+          backend lb0_6969
+              mode tcp
+              balance roundrobin
+              option tcp-check
+              server lb0_10.2.11.200_1234 10.2.11.200:1234 check observe layer4 error-limit 50 on-error mark-down
+              server lb0_10.2.11.201_1234 10.2.11.201:1234 check observe layer4 error-limit 50 on-error mark-down
+      DYNAMIC
+
+      Dir.mktmpdir do |dir|
+          haproxy_vars = Service::HAProxy.extract_backends vnets
+          Service::HAProxy.render_servers_cfg haproxy_vars, basedir: dir
+          result = File.read "#{dir}/servers.cfg"
+          puts "#{output.strip}"
+          expect(result.strip).to eq output.strip
+      end
+  end
 end

--- a/appliances/VRouter/LVS/execute.rb
+++ b/appliances/VRouter/LVS/execute.rb
@@ -17,7 +17,7 @@ module LVS
 
         static = backends.from_env(prefix: 'ONEAPP_VNF_LB', allow_nil_ports: true)
 
-        dynamic = VROUTER_ID.nil? ? backends.from_vms(objects, prefix: 'ONEGATE_LB', id: SERVICE_ID)
+        dynamic = oneflow_api?(SERVICE_ID) ? backends.from_vms(objects, prefix: 'ONEGATE_LB', id: SERVICE_ID)
                                   : backends.from_vnets(objects, prefix: 'ONEGATE_LB', id: VROUTER_ID)
 
         # Replace all "<ETHx_IPy>", "<ETHx_VIPy>" and "<ETHx_EPy>" placeholders where possible.

--- a/appliances/VRouter/LVS/execute.rb
+++ b/appliances/VRouter/LVS/execute.rb
@@ -17,7 +17,7 @@ module LVS
 
         static = backends.from_env(prefix: 'ONEAPP_VNF_LB', allow_nil_ports: true)
 
-        dynamic = oneflow_api?(SERVICE_ID) ? backends.from_vms(objects, prefix: 'ONEGATE_LB', id: SERVICE_ID)
+        dynamic = oneflow_api? ? backends.from_vms(objects, prefix: 'ONEGATE_LB', id: SERVICE_ID)
                                   : backends.from_vnets(objects, prefix: 'ONEGATE_LB', id: VROUTER_ID)
 
         # Replace all "<ETHx_IPy>", "<ETHx_VIPy>" and "<ETHx_EPy>" placeholders where possible.

--- a/appliances/VRouter/LVS/main.rb
+++ b/appliances/VRouter/LVS/main.rb
@@ -17,6 +17,8 @@ module LVS
 
     ONEAPP_VNF_LB_INTERFACES = env :ONEAPP_VNF_LB_INTERFACES, '' # nil -> none, empty -> all
 
+    ONEAPP_VNF_ONEGATE_LB_API = env :ONEAPP_VNF_ONEGATE_LB_API, 'auto'
+
     def install(initdir: '/etc/init.d')
         msg :info, 'LVS::install'
 

--- a/appliances/VRouter/LVS/main.rb
+++ b/appliances/VRouter/LVS/main.rb
@@ -17,7 +17,7 @@ module LVS
 
     ONEAPP_VNF_LB_INTERFACES = env :ONEAPP_VNF_LB_INTERFACES, '' # nil -> none, empty -> all
 
-    ONEAPP_VNF_ONEGATE_LB_API = env :ONEAPP_VNF_ONEGATE_LB_API, 'auto'
+    ONEAPP_VNF_LB_ONEGATE_API = env :ONEAPP_VNF_LB_ONEGATE_API, 'auto'
 
     def install(initdir: '/etc/init.d')
         msg :info, 'LVS::install'

--- a/appliances/VRouter/LVS/tests.rb
+++ b/appliances/VRouter/LVS/tests.rb
@@ -39,14 +39,14 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_LB1_SERVER1_HOST'] = '10.2.200.20'
         ENV['ONEAPP_VNF_LB1_SERVER1_PORT'] = '54321'
 
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = ''
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = ''
 
         load './main.rb'; include Service::LVS
 
         expect(Service::LVS::ONEAPP_VNF_LB_ENABLED).to be true
         expect(Service::LVS::ONEAPP_VNF_LB_REFRESH_RATE).to eq '30'
         expect(Service::LVS::ONEAPP_VNF_LB_FWMARK_OFFSET).to eq '10000'
-        expect(Service::LVS::ONEAPP_VNF_ONEGATE_LB_API).to eq 'auto'
+        expect(Service::LVS::ONEAPP_VNF_LB_ONEGATE_API).to eq 'auto'
 
         Service::LVS.const_set :VROUTER_ID, '86'
 
@@ -111,14 +111,14 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_LB1_SERVER1_ULIMIT'] = '100'
         ENV['ONEAPP_VNF_LB1_SERVER1_LLIMIT'] = '0'
 
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'vrouter'
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'vrouter'
 
         load './main.rb'; include Service::LVS
 
         expect(Service::LVS::ONEAPP_VNF_LB_ENABLED).to be true
         expect(Service::LVS::ONEAPP_VNF_LB_REFRESH_RATE).to eq '45'
         expect(Service::LVS::ONEAPP_VNF_LB_FWMARK_OFFSET).to eq '12345'
-        expect(Service::LVS::ONEAPP_VNF_ONEGATE_LB_API).to eq 'vrouter'
+        expect(Service::LVS::ONEAPP_VNF_LB_ONEGATE_API).to eq 'vrouter'
 
         Service::LVS.const_set :VROUTER_ID, '86'
 
@@ -320,7 +320,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_LB1_SCHEDULER'] = 'rr'
 
         # Internally forced to 'VROUTER' since not in OneFlow
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'service'
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'service'
 
         (vnets ||= []) << JSON.parse(<<~'VNET0')
             {
@@ -487,7 +487,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_LB1_TIMEOUT'] = '5'
         ENV['ONEAPP_VNF_LB1_SCHEDULER'] = 'rr'
 
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'auto'
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'auto'
 
         (vms ||= []) << JSON.parse(<<~'VM0')
             {
@@ -670,7 +670,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_LB3_SERVER0_HOST'] = '10.2.11.300'
         ENV['ONEAPP_VNF_LB3_SERVER0_PORT'] = '7969'
 
-        ENV['ONEAPP_VNF_ONEGATE_LB_API'] = 'vrouter'
+        ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'vrouter'
 
         (vnets ||= []) << JSON.parse(<<~'VNET0')
             {

--- a/appliances/VRouter/LVS/tests.rb
+++ b/appliances/VRouter/LVS/tests.rb
@@ -488,6 +488,7 @@ RSpec.describe self do
         ENV['ONEAPP_VNF_LB1_SCHEDULER'] = 'rr'
 
         ENV['ONEAPP_VNF_LB_ONEGATE_API'] = 'auto'
+        ENV['SERVICE_ID'] = '123'
 
         (vms ||= []) << JSON.parse(<<~'VM0')
             {

--- a/appliances/VRouter/vrouter.rb
+++ b/appliances/VRouter/vrouter.rb
@@ -410,7 +410,7 @@ end
 def oneflow_api?(service_id)
     return false if service_id.nil?
 
-    api = env('ONEAPP_VNF_ONEGATE_LB_API', nil)&.downcase
+    api = env('ONEAPP_VNF_LB_ONEGATE_API', nil)&.downcase
     return api != 'vrouter'
 end
 

--- a/appliances/VRouter/vrouter.rb
+++ b/appliances/VRouter/vrouter.rb
@@ -407,11 +407,9 @@ def get_service_vms # OneFlow
     end
 end
 
-def oneflow_api?(service_id)
-    return false if service_id.nil?
-
-    api = env('ONEAPP_VNF_LB_ONEGATE_API', nil)&.downcase
-    return api != 'vrouter'
+def oneflow_api?
+    return false if env(:SERVICE_ID, nil).nil?
+    return env(:ONEAPP_VNF_LB_ONEGATE_API, nil)&.downcase != 'vrouter'
 end
 
 def backends

--- a/appliances/VRouter/vrouter.rb
+++ b/appliances/VRouter/vrouter.rb
@@ -407,6 +407,13 @@ def get_service_vms # OneFlow
     end
 end
 
+def oneflow_api?(service_id)
+    return false if service_id.nil?
+
+    api = env('ONEAPP_VNF_ONEGATE_LB_API', nil)&.downcase
+    return api != 'vrouter'
+end
+
 def backends
     def parse_static(names, prefix, allow_nil_ports: false)
         names.each_with_object({}) do |name, acc|


### PR DESCRIPTION
This PR introduces a new parameter, `ONEAPP_VNF_LB_ONEGATE_API`, which allows forcing the use of the VR API when deployed in OneFlow. To force the VR API, set `ONEAPP_VNF_LB_ONEGATE_API=vrouter`

By default, when deployed within a OneFlow service instance, the Flow API is used, while the VR API is used if it's an OpenNebula Virtual Router instance.