### PR TITLE
F #-: Ray appliance improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ packer-service_OneKEa: PKR_VAR_airgapped := YES
 packer-service_OneKEa: packer-ubuntu2204oneke $(DIR_EXPORT)/service_OneKEa.qcow2 $(DIR_EXPORT)/service_OneKE_storage.qcow2
 	@$(INFO) "Packer service_OneKEa done"
 
+packer-service_Ray: PKR_VAR_nvidia_driver_path := $(NVIDIA_DRIVER_PATH)
 packer-service_Ray: packer-ubuntu2404 $(DIR_EXPORT)/service_Ray.qcow2
 	@$(INFO) "Packer service_Ray done"
 

--- a/appliances/Ray/config.rb
+++ b/appliances/Ray/config.rb
@@ -17,6 +17,11 @@ PYTHON_VENV   = 'source /root/ray_env/bin/activate'
 
 # These variables are not exposed to the user and only used during install
 ONEAPP_RAY_MODULES = 'default,serve'
+ONEAPP_RAY_RELEASE_VERSION = env :ONEAPP_RAY_RELEASE_VERSION,'2.45.0'
+ONEAPP_RAY_JINJA2_VERSION = env :ONEAPP_RAY_JINJA2_VERSION, '3.1.6'
+ONEAPP_RAY_VLLM_VERSION = env :ONEAPP_RAY_VLLM_VERSION, '0.8.5'
+ONEAPP_RAY_FLASK_VERSION = env :ONEAPP_RAY_FLASK_VERSION,'3.1.0'
+
 ONEAPP_RAY_PORT    = env :ONEAPP_RAY_PORT, '6379'
 
 # ------------------------------------------------------------------------------

--- a/appliances/Ray/config.rb
+++ b/appliances/Ray/config.rb
@@ -90,7 +90,7 @@ RAY_API_ROUTE = '/chat'
 #  ONEAPP_RAY_MODEL_QUANTIZATION 0,4,8 Use quantization for the LLM weights.
 #  (8bits only supported by Ray, 0 = No quantization)
 #
-#  ONEAPP_RAY_MAX_NEW_TOKENS TODO
+#  ONEAPP_RAY_MODEL_MAX_NEW_TOKENS Model context length for prompt and output.
 #
 #  The following model parameters are only for Ray deployments without OpenAI:
 #
@@ -102,7 +102,7 @@ ONEAPP_RAY_MODEL_ID    = env :ONEAPP_RAY_MODEL_ID, 'meta-llama/Llama-3.2-1B-Inst
 ONEAPP_RAY_MODEL_TOKEN = env :ONEAPP_RAY_MODEL_TOKEN, ''
 
 ONEAPP_RAY_MODEL_QUANTIZATION = env :ONEAPP_RAY_MODEL_QUANTIZATION, 0
-ONEAPP_RAY_MAX_NEW_TOKENS     = env :ONEAPP_RAY_MAX_NEW_TOKENS, 512
+ONEAPP_RAY_MODEL_MAX_NEW_TOKENS     = env :ONEAPP_RAY_MODEL_MAX_NEW_TOKENS, 1024
 
 ONEAPP_RAY_MODEL_TEMPERATURE = env :ONEAPP_RAY_MODEL_TEMPERATURE, '0.1'
 ONEAPP_RAY_MODEL_PROMPT      = env :ONEAPP_RAY_MODEL_PROMPT, \

--- a/appliances/Ray/configs/config.yaml.template
+++ b/appliances/Ray/configs/config.yaml.template
@@ -31,7 +31,7 @@ applications:
     token: "<%= ONEAPP_RAY_MODEL_TOKEN %>"
     temperature: <%= ONEAPP_RAY_MODEL_TEMPERATURE %>
     system_prompt: "<%= ONEAPP_RAY_MODEL_PROMPT %>"
-    max_new_tokens: <%= ONEAPP_RAY_MAX_NEW_TOKENS %>
+    max_new_tokens: <%= ONEAPP_RAY_MODEL_MAX_NEW_TOKENS %>
     quantization: <%= quantization %>
   deployments:
   - name: ChatBot

--- a/appliances/Ray/configs/config_vllm.yaml.template
+++ b/appliances/Ray/configs/config_vllm.yaml.template
@@ -31,7 +31,7 @@ applications:
     token: "<%= ONEAPP_RAY_MODEL_TOKEN %>"
     temperature: <%= ONEAPP_RAY_MODEL_TEMPERATURE %>
     system_prompt: "<%= ONEAPP_RAY_MODEL_PROMPT %>"
-    max_new_tokens: <%= ONEAPP_RAY_MAX_NEW_TOKENS %>
+    max_new_tokens: <%= ONEAPP_RAY_MODEL_MAX_NEW_TOKENS %>
     quantization: <%= quantization %>
   deployments:
   - name: ChatBot

--- a/appliances/Ray/main.rb
+++ b/appliances/Ray/main.rb
@@ -129,7 +129,7 @@ module Service
 
     def generate_config_file
         if !ONEAPP_RAY_CONFIG_FILE64.empty?
-            msg :info, "Copying config64 to #{ONEAPP_RAY_CONFIGFILE_DEST_PATH}..."
+            msg :info, "Copying config64 to #{RAY_CONFIG_PATH}..."
 
             config = Base64.decode64(ONEAPP_RAY_CONFIG_FILE64)
 
@@ -208,7 +208,7 @@ module Service
     end
 
     def model_length
-        Integer(ONEAPP_RAY_MAX_NEW_TOKENS)
+        Integer(ONEAPP_RAY_MODEL_MAX_NEW_TOKENS)
     rescue StandardError
         512
     end

--- a/appliances/Ray/main.rb
+++ b/appliances/Ray/main.rb
@@ -97,7 +97,10 @@ module Service
             cd /root
             python3 -m venv ray_env
             source ray_env/bin/activate
-            pip3 install ray[#{ONEAPP_RAY_MODULES}] jinja2==3.1.4 vllm flask
+            pip3 install ray[#{ONEAPP_RAY_MODULES}]==#{ONEAPP_RAY_RELEASE_VERSION} \
+                jinja2==#{ONEAPP_RAY_JINJA2_VERSION} \
+                vllm==#{ONEAPP_RAY_VLLM_VERSION} \
+                flask==#{ONEAPP_RAY_FLASK_VERSION}
         SCRIPT
     end
 

--- a/packer/service_Ray/Ray.pkr.hcl
+++ b/packer/service_Ray/Ray.pkr.hcl
@@ -36,7 +36,8 @@ source "qemu" "Ray" {
 
   output_directory = var.output_dir
 
-  qemuargs = [["-serial", "stdio"],
+  qemuargs = [
+    ["-serial", "stdio"],
     ["-cpu", "host"],
     ["-cdrom", "${var.input_dir}/${var.appliance_name}-context.iso"],
     # MAC addr needs to mach ETH0_MAC from context iso
@@ -48,6 +49,14 @@ source "qemu" "Ray" {
   ssh_wait_timeout = "900s"
   shutdown_command = "poweroff"
   vm_name          = "${var.appliance_name}"
+}
+
+locals {
+  install_nvidia_driver          = var.nvidia_driver_path != "" ? true : false
+  nvidia_driver_local_tmp_dir    = "/tmp"
+  nvidia_driver_local_tmp_path   = "${local.nvidia_driver_local_tmp_dir}/${basename(var.nvidia_driver_path)}"
+  nvidia_driver_remote_dest_dir  = "/tmp"
+  nvidia_driver_remote_dest_path = "${local.nvidia_driver_remote_dest_dir}/${basename(var.nvidia_driver_path)}"
 }
 
 # Once the VM launches the following logic will be executed inside it to customize what happens inside
@@ -93,18 +102,46 @@ build {
   }
 
   provisioner "file" {
-    sources     = [ "appliances/Ray" ]
+    sources     = ["appliances/Ray"]
     destination = "/etc/one-appliance/service.d/"
   }
-
-#  provisioner "file" {
-#    sources = ["${var.input_dir}/nvidia-linux-grid-535_535.216.01_amd64.deb"]
-#    destination = "/var/tmp/nvidia-linux-grid-535_535.216.01_amd64.deb"
-#  }
 
   provisioner "shell" {
     scripts = ["${var.input_dir}/82-configure-context.sh"]
   }
+
+  # Download or copy nvidia driver to local temporary directory before copying it
+  provisioner "shell-local" {
+    execute_command = ["bash", "-c", "{{.Vars}} {{.Script}}"]
+    environment_vars = [
+      "DRIVERS_PATH=${var.nvidia_driver_path}",
+      "DRIVERS_TMP_DEST_DIR=${local.nvidia_driver_local_tmp_dir}",
+    ]
+    scripts = ["${var.input_dir}/get_nvidia_driver.sh"]
+  }
+
+  # With `generated=true` we avoid checking the file existence on prebuild validation
+  # as we are dinamically generating (copying or downloading) the drivers files.
+  # More info: https://developer.hashicorp.com/packer/docs/provisioners/file#generated
+  provisioner "file" {
+    source      = local.install_nvidia_driver ? local.nvidia_driver_local_tmp_path : "/dev/null"
+    destination = local.install_nvidia_driver ? local.nvidia_driver_remote_dest_path : "/dev/null"
+    generated   = true
+  }
+
+  # Delete local temporary driver file after provisioning it
+  provisioner "shell-local" {
+    inline = [<<EOF
+        if [ -n "$DRIVERS_TMP_PATH" ]; then
+            rm -f "$DRIVERS_TMP_PATH";
+        fi
+    EOF
+    ]
+    environment_vars = [
+      "DRIVERS_TMP_PATH=${local.install_nvidia_driver ? local.nvidia_driver_local_tmp_path : ""}",
+    ]
+  }
+
 
   #This is necessary for allowing serve to detect the python modules
   # probably we can do it in a better way
@@ -120,10 +157,22 @@ build {
   # Setup appliance: Execute install step                               #
   # https://github.com/OpenNebula/one-apps/wiki/apps_intro#installation #
   #######################################################################
-#  provisioner "shell" {
-#    inline_shebang = "/bin/bash"
-#    inline         = ["apt-get update --fix-missing; dpkg -i /var/tmp/nvidia-linux-grid-535_535.216.01_amd64.deb; apt --fix-broken install --yes" ]
-#  }
+  # if necessary, install and delete the nvidia driver
+  provisioner "shell" {
+    inline_shebang = "/bin/bash"
+    inline = [<<EOF
+        if [ -n "$DRIVER_PATH" ]; then
+            apt-get update --fix-missing;
+            dpkg -i "$DRIVER_PATH";
+            apt --fix-broken install --yes;
+            rm -f \"$DRIVER_PATH\";
+        fi
+    EOF
+    ]
+    environment_vars = [
+      "DRIVER_PATH=${local.install_nvidia_driver ? local.nvidia_driver_remote_dest_path : ""}"
+    ]
+  }
 
   provisioner "shell" {
     inline_shebang = "/bin/bash -e"

--- a/packer/service_Ray/get_nvidia_driver.sh
+++ b/packer/service_Ray/get_nvidia_driver.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+####
+# This script is used to download NVIDIA drivers from a given URL or copy them
+# from a local path to a specified temporary destination directory.
+# Arguments:
+#   - DRIVERS_PATH: URL or local path to the NVIDIA drivers.
+#   - DRIVERS_TMP_DEST_DIR: Temporary directory to store the downloaded drivers.
+###
+
+
+###  Functions
+
+is_url() {
+  case "$1" in
+    http://*|https://*)
+        return 0
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+download_drivers() {
+    local _url=$1
+    local _dest=$2
+    if command -v wget > /dev/null 2>&1; then
+        wget -P "$_dest" "$_url"
+    elif command -v curl > /dev/null 2>&1; then
+        curl -fsO --output-dir "$_dest" "$_url"
+    else
+        echo "Error: No wget or curl binaries installed, unable to download drivers."
+        return 1
+    fi
+}
+
+### Script start
+
+echo "Downloading/copying NVIDIA drivers from $DRIVERS_PATH to $DRIVERS_TMP_DEST_DIR ..."
+
+if [ -z "$DRIVERS_PATH" ]; then
+    echo "No driver path specified (DRIVERS_PATH), ignoring NVIDIA drivers installation..."
+    exit
+fi
+
+if [ -z "$DRIVERS_TMP_DEST_DIR" ]; then
+    echo "No temporary destination directory specified (DRIVERS_TMP_DEST_DIR), unable to proceed..."
+    exit
+fi
+
+mkdir -p "$DRIVERS_TMP_DEST_DIR"
+
+if is_url "$DRIVERS_PATH"; then
+    download_drivers "$DRIVERS_PATH" "$DRIVERS_TMP_DEST_DIR"
+else
+    if [ -f "$DRIVERS_PATH" ]; then
+        cp "$DRIVERS_PATH" "$DRIVERS_TMP_DEST_DIR"
+    else
+        echo "Error: File '$DRIVERS_PATH' does not exist"
+        exit 1
+    fi
+fi

--- a/packer/service_Ray/variables.pkr.hcl
+++ b/packer/service_Ray/variables.pkr.hcl
@@ -20,3 +20,8 @@ variable "version" {
   type    = string
   default = ""
 }
+
+variable "nvidia_driver_path" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
- Allows pinning the Ray and dependencies versions.
- Implements the packaging of the nvidia driver from an url or a local path.
- Renames `ONEAPP_RAY_MAX_NEW_TOKENS` to `ONEAPP_RAY_MODEL_MAX_NEW_TOKENS` for being consistent with the standard.
- Changes the default for `ONEAPP_RAY_MODEL_MAX_NEW_TOKENS` from `512` to `1024` for being consistent with the [documentation](https://github.com/OpenNebula/one-apps/wiki/ray_feature#contextualization).