### PR TITLE
B #-: Fix Ray model load error when no auth token is set

### DIFF
--- a/appliances/Ray/config.rb
+++ b/appliances/Ray/config.rb
@@ -148,12 +148,17 @@ def gen_template_config
 
     return if template_path.empty?
 
+    instantiate_template(template_path, RAY_CONFIG_PATH)
+end
+
+def instantiate_template(template_path, output_path)
     template = File.read(template_path)
 
-    erb    = ERB.new(template)
+    # trim
+    erb    = ERB.new(template, nil , '-')
     result = erb.result(binding)
 
-    write_file(RAY_CONFIG_PATH, result)
+    write_file(output_path, result)
 end
 
 def gen_model

--- a/appliances/Ray/configs/config.yaml.template
+++ b/appliances/Ray/configs/config.yaml.template
@@ -28,7 +28,9 @@ applications:
       - bitsandbytes==0.45.0
   args:
     model_id: "<%= ONEAPP_RAY_MODEL_ID %>"
+<% if ONEAPP_RAY_MODEL_TOKEN && !ONEAPP_RAY_MODEL_TOKEN.empty? -%>
     token: "<%= ONEAPP_RAY_MODEL_TOKEN %>"
+<% end -%>
     temperature: <%= ONEAPP_RAY_MODEL_TEMPERATURE %>
     system_prompt: "<%= ONEAPP_RAY_MODEL_PROMPT %>"
     max_new_tokens: <%= ONEAPP_RAY_MODEL_MAX_NEW_TOKENS %>

--- a/appliances/Ray/configs/config_vllm.yaml.template
+++ b/appliances/Ray/configs/config_vllm.yaml.template
@@ -28,7 +28,9 @@ applications:
       - bitsandbytes==0.45.0
   args:
     model_id: "<%= ONEAPP_RAY_MODEL_ID %>"
+<% if ONEAPP_RAY_MODEL_TOKEN && !ONEAPP_RAY_MODEL_TOKEN.empty? -%>
     token: "<%= ONEAPP_RAY_MODEL_TOKEN %>"
+<% end -%>
     temperature: <%= ONEAPP_RAY_MODEL_TEMPERATURE %>
     system_prompt: "<%= ONEAPP_RAY_MODEL_PROMPT %>"
     max_new_tokens: <%= ONEAPP_RAY_MODEL_MAX_NEW_TOKENS %>

--- a/appliances/Ray/models/model.py
+++ b/appliances/Ray/models/model.py
@@ -29,16 +29,16 @@ bnb_config = {
 @serve.ingress(app)
 class ChatBot:
     def __init__(
-            self, 
-            model_id: str, 
-            token: str, 
-            temperature: float, 
+            self,
+            model_id: str,
+            token: str,
+            temperature: float,
             system_prompt: str,
             max_new_tokens: int,
             quantization: int=0):
         """Default class for conversational chatbot using vLLM and Ray appliance.
         Args:
-            model_id (str): HuggingFace model ID from the model that we want to deploy. 
+            model_id (str): HuggingFace model ID from the model that we want to deploy.
             token (str): HuggingFace token to be used for authentication.
             temperature (str): temperature of the model, randomness.
             system_prompt (str): system prompt to define the behaviour of the LLM.
@@ -58,11 +58,11 @@ class ChatBot:
         else:
             self.model = AutoModelForCausalLM.from_pretrained(
                 model_id, token=token, device_map="auto")
-            
+
         # Identify model params
         self.temperature = temperature
         self.system_prompt = system_prompt
-        self.max_new_tokens = max_new_tokens 
+        self.max_new_tokens = max_new_tokens
 
         # Check if there is chat_template
         if self.tokenizer.chat_template is None:
@@ -80,7 +80,7 @@ class ChatBot:
 
     @app.post("/chat")
     async def chat(
-        self, 
+        self,
         text: str) -> str:
         """Endpoint to communicate with deployed LLM.
         Args:
@@ -96,18 +96,18 @@ class ChatBot:
 
         # Apply chat template and tokenize
         chat = self.tokenizer.apply_chat_template(
-            self.messages, 
-            tokenize=False, 
-            add_generation_prompt=True, 
+            self.messages,
+            tokenize=False,
+            add_generation_prompt=True,
             return_tensors="pt")
         input_tokens = self.tokenizer(
             chat, return_tensors="pt").to(self.model.device)
 
         # Run inference
         output = self.model.generate(
-            **input_tokens, 
+            **input_tokens,
             max_new_tokens=self.max_new_tokens)
-        
+
         # Decode output tokens into text
         prompt_length = input_tokens['input_ids'].shape[1]
         output = self.tokenizer.decode(output[0][prompt_length:])
@@ -115,13 +115,13 @@ class ChatBot:
 
         # Add it to conversation
         return answer
-    
+
 
 def app_builder(args: Dict[str, str]) -> Application:
     return ChatBot.bind(
-        args["model_id"], 
-        args['token'], 
-        args['temperature'], 
+        args["model_id"],
+        args.get('token', None),
+        args['temperature'],
         args['system_prompt'],
         args['max_new_tokens'],
         args['quantization'])

--- a/appliances/Ray/models/model_openai.py
+++ b/appliances/Ray/models/model_openai.py
@@ -48,12 +48,12 @@ bnb_config = {
 @serve.ingress(app)
 class ChatBot:
     def __init__(
-            self, 
-            model_id: str, 
+            self,
+            model_id: str,
             token: str,
             quantization: int=0):
         # Load model and tokenizer
-        self.model_id = model_id 
+        self.model_id = model_id
         self.tokenizer = AutoTokenizer.from_pretrained(
             model_id, token=token)
         self.model = AutoModelForCausalLM.from_pretrained(
@@ -81,9 +81,9 @@ class ChatBot:
         return self.tokenizer.decode(output[0], skip_special_tokens=True)
 
     def _generate_chat_completions(
-            self, 
-            messages: List[ChatMessage], 
-            temperature: float, 
+            self,
+            messages: List[ChatMessage],
+            temperature: float,
             max_tokens: int) -> dict:
         """Generates chat completions using the Hugging Face model."""
         # Apply chat template and tokenize
@@ -146,6 +146,6 @@ class ChatBot:
 
 def app_builder(args: Dict[str, str]) -> Application:
     return ChatBot.bind(
-        args["model_id"], 
-        args['token'],
+        args["model_id"],
+        args.get('token', None),
         args['quantization'])

--- a/appliances/Ray/models/model_vllm.py
+++ b/appliances/Ray/models/model_vllm.py
@@ -15,10 +15,10 @@ app = FastAPI()
 @serve.ingress(app)
 class ChatBot:
     def __init__(
-            self, 
-            model_id: str, 
-            token:str, 
-            temperature: float, 
+            self,
+            model_id: str,
+            token:str,
+            temperature: float,
             system_prompt: str,
             max_new_tokens: int,
             quantization: int=0):
@@ -38,21 +38,21 @@ class ChatBot:
         # Load model
         if quantization > 0:
             self.model = LLM(
-                model=model_id, gpu_memory_utilization=0.8, 
+                model=model_id, gpu_memory_utilization=0.8,
                 tensor_parallel_size=torch.cuda.device_count(),
                 quantization="bitsandbytes", load_format="bitsandbytes",
                 dtype=torch.bfloat16)
         else:
             self.model = LLM(
-                model=model_id, gpu_memory_utilization=0.8, 
+                model=model_id, gpu_memory_utilization=0.8,
                 tensor_parallel_size=torch.cuda.device_count(),
                 dtype=torch.bfloat16)
-            
+
         # Identify model params
         self.temperature = temperature
         self.system_prompt = system_prompt
         self.max_new_tokens = max_new_tokens
-        
+
     @app.post("/chat")
     async def chat(
         self, text: str) -> str:
@@ -82,9 +82,9 @@ class ChatBot:
 
 def app_builder(args: Dict[str, str]) -> Application:
     return ChatBot.bind(
-        args["model_id"], 
-        args['token'], 
-        args['temperature'], 
+        args["model_id"],
+        args.get('token', None),
+        args['temperature'],
         args['system_prompt'],
         args['max_new_tokens'],
         args['quantization'])


### PR DESCRIPTION
This PR fixes a bug in Ray appliance: when the model application tries to download the language model from hugging face, if the `ONEAPP_RAY_MODEL_TOKEN` is empty or not set, the authorization fails against Hugging Face API.

Useful for not having to add the temporary authorization token in context tests.