### PR TITLE
M #-: Lock version of QEMU packer plugin

### DIFF
--- a/packer/common.pkr.hcl
+++ b/packer/common.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     qemu = {
       source  = "github.com/hashicorp/qemu"
-      version = "~> 1"
+      version = "1.1.0"
     }
   }
 }


### PR DESCRIPTION
Locks QEMU Packer plugin version to 1.1.0 to avoid a change introduced in a recent [version](https://github.com/hashicorp/packer-plugin-qemu/issues/198) that shuts down the VM during image build time.