### PR TITLE
Increases ubuntu2204 vdisk size to 4096

### DIFF
--- a/packer/ubuntu/ubuntu.pkr.hcl
+++ b/packer/ubuntu/ubuntu.pkr.hcl
@@ -15,6 +15,7 @@ locals {
   disk_size = lookup({
     "2204oneke"         = 3072
     "2204oneke.aarch64" = 3072
+    "2204"              = 4096
   }, var.version, 0)
 }
 


### PR DESCRIPTION
Avoids problem during packer builds:
```
==> qemu.ubuntu: update-initramfs: Generating /boot/initrd.img-5.15.0-140-generic
==> qemu.ubuntu: zstd: error 25 : Write error : No space left on device (cannot write compressed block)
==> qemu.ubuntu: E: mkinitramfs failure zstd -q -1 -T0 25
==> qemu.ubuntu: update-initramfs: failed for /boot/initrd.img-5.15.0-140-generic with 1.
==> qemu.ubuntu: dpkg: error processing package initramfs-tools (--configure):
==> qemu.ubuntu:  installed initramfs-tools package post-installation script subprocess returned error exit status 1
==> qemu.ubuntu: Errors were encountered while processing:
==> qemu.ubuntu:  initramfs-tools
==> qemu.ubuntu: needrestart is being skipped since dpkg has failed
==> qemu.ubuntu: E: Sub-process /usr/bin/dpkg returned an error code (1)

```