### PR TITLE
M #-: Rework Packer scripts for RHEL10

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -75,7 +75,7 @@ DIR_EXPORT := export
 $(shell mkdir -p $(DIR_BUILD) $(DIR_EXPORT))
 
 # don't delete exported
-.SECONDARY: $(DISTROS:%=$(DIR_EXPORT)/%.qcow2) $(SERVICES:%=$(DIR_EXPORT)/%.qcow2)
+.PRECIOUS: $(DIR_EXPORT)/%.qcow2
 
 .PHONY: context-linux context-windows context-iso help
 

--- a/packer/rhel/10-upgrade-distro.sh.10
+++ b/packer/rhel/10-upgrade-distro.sh.10
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Install required packages and upgrade the distro.
+
+exec 1>&2
+set -eux -o pipefail
+
+# Make sure /etc/machine-id exists otherwise this can happen:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1737355
+systemd-machine-id-setup
+
+ln -sf ../usr/share/zoneinfo/UTC /etc/localtime
+
+subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms
+
+dnf install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm"
+
+dnf repolist enabled
+
+dnf update -y
+
+# Ensure packages needed for post-processing scripts do exist.
+dnf install -y curl gawk grep jq sed
+
+sync

--- a/packer/rhel/10-upgrade-distro.sh.10.aarch64
+++ b/packer/rhel/10-upgrade-distro.sh.10.aarch64
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Install required packages and upgrade the distro.
+
+exec 1>&2
+set -eux -o pipefail
+
+# Make sure /etc/machine-id exists otherwise this can happen:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1737355
+systemd-machine-id-setup
+
+ln -sf ../usr/share/zoneinfo/UTC /etc/localtime
+
+subscription-manager repos --enable codeready-builder-for-rhel-10-aarch64-rpms
+
+dnf install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm"
+
+dnf repolist enabled
+
+dnf update -y
+
+# Ensure packages needed for post-processing scripts do exist.
+dnf install -y curl gawk grep jq sed
+
+sync

--- a/packer/rhel/80-install-context.sh.10
+++ b/packer/rhel/80-install-context.sh.10
@@ -2,7 +2,7 @@
 
 # Download and install the latest one-context package.
 
-: "${CTXEXT:=el9.noarch.rpm}"
+: "${CTXEXT:=el10.noarch.rpm}"
 
 exec 1>&2
 set -eux -o pipefail

--- a/packer/rhel/80-install-context.sh.10.aarch64
+++ b/packer/rhel/80-install-context.sh.10.aarch64
@@ -2,7 +2,7 @@
 
 # Download and install the latest one-context package.
 
-: "${CTXEXT:=el9.noarch.rpm}"
+: "${CTXEXT:=el10.noarch.rpm}"
 
 exec 1>&2
 set -eux -o pipefail

--- a/packer/rhel/99-unsubscribe.sh
+++ b/packer/rhel/99-unsubscribe.sh
@@ -3,7 +3,7 @@
 exec 1>&2
 set -eux -o pipefail
 
-subscription-manager remove --all
+subscription-manager remove --all ||:
 subscription-manager unregister
 subscription-manager clean
 


### PR DESCRIPTION
- RHEL10 now uses SCA, no register needed
- don't delete created images in exported/ so we can adjust DISTROS vars in Makefile.local
- adjust RHEL10 packer scripts