### PR TITLE
M #-: Deprecate alpine 318 and 319 versions due to EOL

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -7,8 +7,8 @@ VERBOSE         := 1
 PACKER_LOG      := 0
 PACKER_HEADLESS := true
 
-DISTROS_AMD64 := alma8 alma9 alma10\
-                 alpine318 alpine319 alpine320 alpine321 alpine322\
+DISTROS_AMD64 := alma8 alma9 alma10 \
+                 alpine320 alpine321 alpine322 \
                  alt10 \
                  amazon2 amazon2023 \
                  debian11 debian12 debian13 \
@@ -22,8 +22,8 @@ DISTROS_AMD64 := alma8 alma9 alma10\
                  ubuntu2204 ubuntu2204min ubuntu2204oneke \
                  ubuntu2404 ubuntu2404min
 
-DISTROS_ARM64 := alma8.aarch64 alma9.aarch64 alma10.aarch64\
-                 alpine318.aarch64 alpine319.aarch64 alpine320.aarch64 alpine321.aarch64 alpine322.aarch64\
+DISTROS_ARM64 := alma8.aarch64 alma9.aarch64 alma10.aarch64 \
+                 alpine320.aarch64 alpine321.aarch64 alpine322.aarch64 \
                  debian11.aarch64 debian12.aarch64 debian13.aarch64 \
                  fedora39.aarch64 fedora40.aarch64 fedora41.aarch64 fedora42.aarch64 \
                  opensuse15.aarch64 \

--- a/packer/alpine/variables.pkr.hcl
+++ b/packer/alpine/variables.pkr.hcl
@@ -2,24 +2,6 @@ variable "alpine" {
   type = map(map(string))
 
   default = {
-    "318.x86_64" = {
-      iso_url      = "https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/cloud/nocloud_alpine-3.19.12-x86_64-bios-cloudinit-r0.qcow2"
-      iso_checksum = "file:https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/cloud/nocloud_alpine-3.19.12-x86_64-bios-cloudinit-r0.qcow2.sha512"
-    }
-    "318.aarch64" = {
-      iso_url      = "https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/cloud/nocloud_alpine-3.19.12-aarch64-uefi-cloudinit-r0.qcow2"
-      iso_checksum = "file:https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/cloud/nocloud_alpine-3.19.12-aarch64-uefi-cloudinit-r0.qcow2.sha512"
-    }
-
-    "319.x86_64" = {
-      iso_url      = "https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/cloud/nocloud_alpine-3.19.9-x86_64-bios-cloudinit-r0.qcow2"
-      iso_checksum = "file:https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/cloud/nocloud_alpine-3.19.9-x86_64-bios-cloudinit-r0.qcow2.sha512"
-    }
-    "319.aarch64" = {
-      iso_url      = "https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/cloud/nocloud_alpine-3.19.9-aarch64-uefi-cloudinit-r0.qcow2"
-      iso_checksum = "file:https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/cloud/nocloud_alpine-3.19.9-aarch64-uefi-cloudinit-r0.qcow2.sha512"
-    }
-
     "320.x86_64" = {
       iso_url      = "https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/cloud/nocloud_alpine-3.20.8-x86_64-bios-cloudinit-r0.qcow2"
       iso_checksum = "file:https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/cloud/nocloud_alpine-3.20.8-x86_64-bios-cloudinit-r0.qcow2.sha512"


### PR DESCRIPTION
Deprecate old alpine 318 and 319 versions due to EOL (https://endoflife.date/alpine-linux)