### PR TITLE
B #-: Require sr0 before running context

### DIFF
--- a/context-linux/src/usr/lib/systemd/system/one-context-local.service##deb.systemd.one
+++ b/context-linux/src/usr/lib/systemd/system/one-context-local.service##deb.systemd.one
@@ -1,9 +1,10 @@
 [Unit]
 Description=OpenNebula pre-networking contextualization
 DefaultDependencies=no
+Requires=dev-sr0.device
 Wants=network-pre.target local-fs.target syslog.target
 Before=network-pre.target
-After=local-fs.target syslog.target
+After=local-fs.target syslog.target dev-sr0.device
 ConditionPathExists=!/var/run/one-context/context.sh.local
 
 [Service]

--- a/context-linux/src/usr/lib/systemd/system/one-context-local.service##rpm.systemd.one
+++ b/context-linux/src/usr/lib/systemd/system/one-context-local.service##rpm.systemd.one
@@ -1,8 +1,9 @@
 [Unit]
 Description=OpenNebula pre-networking contextualization
+Requires=dev-sr0.device
 Wants=network-pre.target local-fs.target syslog.target
 Before=network-pre.target
-After=local-fs.target syslog.target
+After=local-fs.target syslog.target dev-sr0.device
 ConditionPathExists=!/var/run/one-context/context.sh.local
 
 [Service]


### PR DESCRIPTION
In q35 architectures, sometimes one-context services run before udev has activated the sr0 device for the context CDROM, so contextualization fails. This commit explicitly makes the one-context-local service depend on /dev/sr0 being present.