### PR TITLE
M #-: Revert Debian 11/12 to generic images due to CD-ROM issues

### DIFF
--- a/packer/debian/variables.pkr.hcl
+++ b/packer/debian/variables.pkr.hcl
@@ -3,22 +3,22 @@ variable "debian" {
 
   default = {
     "11.x86_64" = {
-      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2"
+      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bullseye/latest/debian-11-generic-amd64.qcow2"
       iso_checksum = "file:https://cdimage.debian.org/cdimage/cloud/bullseye/latest/SHA512SUMS"
     }
 
     "11.aarch64" = {
-      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bullseye/latest/debian-11-genericcloud-arm64.qcow2"
+      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bullseye/latest/debian-11-generic-arm64.qcow2"
       iso_checksum = "file:https://cdimage.debian.org/cdimage/cloud/bullseye/latest/SHA512SUMS"
     }
 
     "12.x86_64" = {
-      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bookworm/latest/debian-12-generic-amd64.qcow2"
       iso_checksum = "file:https://cdimage.debian.org/cdimage/cloud/bookworm/latest/SHA512SUMS"
     }
 
     "12.aarch64" = {
-      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2"
+      iso_url      = "https://cdimage.debian.org/cdimage/cloud/bookworm/latest/debian-12-generic-arm64.qcow2"
       iso_checksum = "file:https://cdimage.debian.org/cdimage/cloud/bookworm/latest/SHA512SUMS"
     }
 


### PR DESCRIPTION
With the default `q35` machine type, Debian 11 and 12 cloud images do not detect IDE/SATA CD-ROM devices.
Switch these versions back to generic images.

Debian 13 cloud images function correctly and remain unchanged.