### PR TITLE
B #-: Replace Require with Wants for sr0

### DIFF
--- a/context-linux/src/usr/lib/systemd/system/one-context-local.service##deb.systemd.one
+++ b/context-linux/src/usr/lib/systemd/system/one-context-local.service##deb.systemd.one
@@ -1,8 +1,7 @@
 [Unit]
 Description=OpenNebula pre-networking contextualization
 DefaultDependencies=no
-Requires=dev-sr0.device
-Wants=network-pre.target local-fs.target syslog.target
+Wants=dev-sr0.device network-pre.target local-fs.target syslog.target
 Before=network-pre.target
 After=local-fs.target syslog.target dev-sr0.device
 ConditionPathExists=!/var/run/one-context/context.sh.local

--- a/context-linux/src/usr/lib/systemd/system/one-context-local.service##rpm.systemd.one
+++ b/context-linux/src/usr/lib/systemd/system/one-context-local.service##rpm.systemd.one
@@ -1,7 +1,6 @@
 [Unit]
 Description=OpenNebula pre-networking contextualization
-Requires=dev-sr0.device
-Wants=network-pre.target local-fs.target syslog.target
+Wants=dev-sr0.device network-pre.target local-fs.target syslog.target
 Before=network-pre.target
 After=local-fs.target syslog.target dev-sr0.device
 ConditionPathExists=!/var/run/one-context/context.sh.local


### PR DESCRIPTION
In aarch64 architectures, the sr0 device may not be present, preventing network activation. This commit changes the Requires dependency on dev-sr0.device to Wants, so contextualization proceeds regardless of sr0 availability.