### PR TITLE
B #-: Various Linux contextualization issues

### DIFF
--- a/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
@@ -177,9 +177,16 @@ EOT
     fi
 
     if [ -n "${ip6_gateway}" ] && { [ -z "${ip6_method}" ] || [ "${ip6_method}" = 'static' ]; }; then
+        # Mark the default route as on-link. The gateway always lives in the
+        # NIC's own subnet, but systemd-networkd (e.g. systemd 259 on Ubuntu
+        # 26.04) refuses to install an IPv6 default route when the same
+        # gateway is already reachable via another link - it then keeps the
+        # interface stuck in the 'configuring' state. on-link skips that
+        # reachability check.
         cat <<EOT
         - to: "::/0"
           via: ${ip6_gateway}
+          on-link: true
 EOT
 
         # Force default Linux IPv6 metric (man 8 route) to override

--- a/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
+++ b/context-linux/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
@@ -239,6 +239,14 @@ EOT
     if [ -n "$ip6_gateway" ]; then
         echo "Gateway=${ip6_gateway}"
 
+        # Mark the default route as on-link. The gateway always lives in the
+        # NIC's own subnet, but systemd-networkd (e.g. systemd 259 on Ubuntu
+        # 26.04) refuses to install an IPv6 default route when the same
+        # gateway is already reachable via another link - it then keeps the
+        # interface stuck in the 'configuring' state. GatewayOnLink skips
+        # that reachability check.
+        echo "GatewayOnLink=yes"
+
         if [ -n "$ip6_metric" ]; then
             echo "Metric=${ip6_metric}"
         fi

--- a/context-linux/src/usr/bin/onegate.rb
+++ b/context-linux/src/usr/bin/onegate.rb
@@ -462,7 +462,11 @@ module OneGate
 
         def get(path, extra = nil)
             req = Net::HTTP::Proxy(@host, @port)::Get.new(path)
-            req.body = extra if extra
+
+            if extra
+                req.body = extra
+                req.content_type = 'application/x-www-form-urlencoded'
+            end
 
             do_request(req)
         end
@@ -476,6 +480,7 @@ module OneGate
         def post(path, body)
             req = Net::HTTP::Proxy(@host, @port)::Post.new(path)
             req.body = body
+            req.content_type = 'application/json'
 
             do_request(req)
         end
@@ -483,6 +488,10 @@ module OneGate
         def put(path, body)
             req = Net::HTTP::Proxy(@host, @port)::Put.new(path)
             req.body = body
+            # Set explicitly: Ruby 4.0 (e.g. Fedora 44) no longer defaults the
+            # body Content-Type to application/x-www-form-urlencoded, and the
+            # OneGate server needs it to parse the form-encoded params.
+            req.content_type = 'application/x-www-form-urlencoded'
 
             do_request(req)
         end

--- a/context-linux/src/usr/lib/udev/rules.d/65-context.rules##apk.one
+++ b/context-linux/src/usr/lib/udev/rules.d/65-context.rules##apk.one
@@ -29,8 +29,10 @@ SUBSYSTEM=="scsi", ACTION=="change", \
   ENV{SDEV_UA}=="CAPACITY_DATA_HAS_CHANGED", \
   RUN+="/sbin/service one-context-force restart"
 
-# Handle swap hot-attach
+# Handle swap hot-attach (exclude zram: distros such as Fedora use a zram
+# swap device that appears on every boot and would force a needless re-run)
 SUBSYSTEM=="block", ACTION=="add", \
+  KERNEL!="zram*", \
   ENV{ID_FS_TYPE}=="swap", \
   ENV{DM_ACTIVATION}!="1", \
   RUN+="/sbin/service one-context-force restart"

--- a/context-linux/src/usr/lib/udev/rules.d/65-context.rules##deb.one
+++ b/context-linux/src/usr/lib/udev/rules.d/65-context.rules##deb.one
@@ -29,8 +29,10 @@ SUBSYSTEM=="scsi", ACTION=="change", \
   ENV{SDEV_UA}=="CAPACITY_DATA_HAS_CHANGED", \
   RUN+="/bin/sh -c '/bin/systemctl --no-block start one-context-force.service || /usr/sbin/service one-context-force start'"
 
-# Handle swap hot-attach
+# Handle swap hot-attach (exclude zram: distros such as Fedora use a zram
+# swap device that appears on every boot and would force a needless re-run)
 SUBSYSTEM=="block", ACTION=="add", \
+  KERNEL!="zram*", \
   ENV{ID_FS_TYPE}=="swap", \
   ENV{DM_ACTIVATION}!="1", \
   RUN+="/bin/sh -c '/bin/systemctl --no-block start one-context-force.service || /usr/sbin/service one-context-force start'"

--- a/context-linux/src/usr/lib/udev/rules.d/65-context.rules##rpm.systemd.one
+++ b/context-linux/src/usr/lib/udev/rules.d/65-context.rules##rpm.systemd.one
@@ -29,8 +29,10 @@ SUBSYSTEM=="scsi", ACTION=="change", \
   ENV{SDEV_UA}=="CAPACITY_DATA_HAS_CHANGED", \
   RUN+="/usr/bin/systemctl --no-block start one-context-force.service"
 
-# Handle swap hot-attach
+# Handle swap hot-attach (exclude zram: distros such as Fedora use a zram
+# swap device that appears on every boot and would force a needless re-run)
 SUBSYSTEM=="block", ACTION=="add", \
+  KERNEL!="zram*", \
   ENV{ID_FS_TYPE}=="swap", \
   ENV{DM_ACTIVATION}!="1", \
   RUN+="/usr/bin/systemctl --no-block start one-context-force.service"

--- a/context-linux/src/usr/lib/udev/rules.d/65-context.rules##rpm.sysv.one
+++ b/context-linux/src/usr/lib/udev/rules.d/65-context.rules##rpm.sysv.one
@@ -21,8 +21,10 @@ SUBSYSTEM=="scsi", ACTION=="change", \
   ENV{SDEV_UA}=="CAPACITY_DATA_HAS_CHANGED", \
   RUN+="/sbin/service one-context-force start"
 
-# Handle swap hot-attach
+# Handle swap hot-attach (exclude zram: distros such as Fedora use a zram
+# swap device that appears on every boot and would force a needless re-run)
 SUBSYSTEM=="block", ACTION=="add", \
+  KERNEL!="zram*", \
   ENV{ID_FS_TYPE}=="swap", \
   ENV{DM_ACTIVATION}!="1", \
   RUN+="/sbin/service one-context-force start"

--- a/packer/ubuntu/98-collect-garbage.sh
+++ b/packer/ubuntu/98-collect-garbage.sh
@@ -13,7 +13,7 @@ export DEBIAN_FRONTEND=noninteractive
 cloud_init_pkgs=$(dpkg-query -W -f='${Package}\n' 'cloud-init*' 2>/dev/null \
     | grep -xE 'cloud-init(-base)?' || true)
 
-apt-get purge -y $cloud_init_pkgs snapd fwupd
+apt-get purge -y $cloud_init_pkgs snapd fwupd open-vm-tools
 
 apt-get autoremove -y --purge
 


### PR DESCRIPTION
* IPv6 default GW: add on-link (Ubuntu 2604)
* Remove one-vm-tools/vstoolsd (Ubuntu 2604)
* onegate.rb: Add content-type (Fedora 44)
* activating ZRAM: Don't force re-context (Fedora 44)