### PR TITLE
M #-: Remove snapd purge from Ubuntu

### DIFF
--- a/packer/ubuntu/98-collect-garbage.sh
+++ b/packer/ubuntu/98-collect-garbage.sh
@@ -13,7 +13,7 @@ export DEBIAN_FRONTEND=noninteractive
 cloud_init_pkgs=$(dpkg-query -W -f='${Package}\n' 'cloud-init*' 2>/dev/null \
     | grep -xE 'cloud-init(-base)?' || true)
 
-apt-get purge -y $cloud_init_pkgs snapd fwupd open-vm-tools
+apt-get purge -y $cloud_init_pkgs fwupd open-vm-tools
 
 apt-get autoremove -y --purge
 


### PR DESCRIPTION
Remove snapd purge from Ubuntu. Required for Canonical kubernetes